### PR TITLE
Provide parameter that works for Mechanical Rock

### DIFF
--- a/functions/AutoRemediateCT-001.js
+++ b/functions/AutoRemediateCT-001.js
@@ -17,7 +17,7 @@ module.exports.handler = (event, context, callback) => {
 	let params = {
 		Name:                       config["AutoRemediateCT-001"]["Name"],
 		S3BucketName:               config["AutoRemediateCT-001"]["S3BucketName"],
-		IncludeGlobalServiceEvents: (event.region === "us-east-1"),
+		IncludeGlobalServiceEvents: config["AutoRemediateCT-001"]["IncludeGlobalServiceEvents"],
 		IsMultiRegionTrail:         config["AutoRemediateCT-001"]["IsMultiRegionTrail"],
 		S3KeyPrefix:                config["AutoRemediateCT-001"]["S3KeyPrefix"]
 


### PR DESCRIPTION
We find we receive an error message with the "us-east-1" parameter value instead of "true":

    2017-11-15T01:06:45.283Z 3ebd24a9-c9a1-11e7-b120-ab9e4717955c ErrorInvalidParameterCombinationException: Multi-Region trail must include global service events.

We deploy to ap-southeast-2.