### PR TITLE
feat: PD-4142 configure split stack migration strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Here's an example:
 
 
 ## Installation
+Note that you need to follow the [Deleting a stack on the AWS CloudFormation console](https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-delete-stack.html) to delete the current stack if you plan to update to the latest version.
+
 1. Go to the official [Serverless Framework](https://serverless.com/framework/docs/providers/aws/guide/installation/)  and follow the instructions to install the framework
 2. Create a working copy of "Cloud Conformity Auto Remediation" repository by running the following command:
 ```bash

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,8 +15,8 @@ provider:
 
 custom:
   splitStacks:
-    perFunction: false
-    perType: true
+    perFunction: true
+    perType: false
     perGroupFunction: false
 
 functions:

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,9 +15,7 @@ provider:
 
 custom:
   splitStacks:
-    perFunction: true
-    perType: false
-    perGroupFunction: false
+    custom: stacks-map.js
 
 functions:
 

--- a/stacks-map.js
+++ b/stacks-map.js
@@ -1,0 +1,14 @@
+module.exports = {
+  "AWS::Lambda::Function": { destination: "Function" },
+  "AWS::IAM::Role": { destination: "Role" },
+  "AWS::Logs::LogGroup": { destination: "Log" },
+  "AWS::Lambda::Version": { desination: "Function" },
+  "AWS::S3::BucketPolicy": { desination: "Policy" },
+  "AWS::SQS::QueuePolicy": { desination: "Policy" },
+  "AWS::SNS::Subscription": { destination: "Infrastructure" },
+  "AWS::S3::Bucket": { destination: "Infrastructure" },
+  "AWS::KMS::Key": { destination: "Infrastructure" },
+  "AWS::KMS::Alias": { destination: "Infrastructure" },
+  "AWS::SNS::Topic": { destination: "Infrastructure" },
+  "AWS::SQS::Queue": { destination: "Infrastructure" }
+};


### PR DESCRIPTION
PD-4142
PD-7377

After comparing with different migration strategies, I decided to use `perFunction` which will create 50 nested stacks and the maximum number of resources is 104 in the (root) stack. It’s more scalable comparing with perType option which will create 3 nested stacks with maximum number of resources is 155.