### PR TITLE
fix: PD-4142 update stack-map.js to resolve the deployment issue

### DIFF
--- a/stacks-map.js
+++ b/stacks-map.js
@@ -4,11 +4,5 @@ module.exports = {
   "AWS::Logs::LogGroup": { destination: "Log" },
   "AWS::Lambda::Version": { desination: "Function" },
   "AWS::S3::BucketPolicy": { desination: "Policy" },
-  "AWS::SQS::QueuePolicy": { desination: "Policy" },
-  "AWS::SNS::Subscription": { destination: "Infrastructure" },
-  "AWS::S3::Bucket": { destination: "Infrastructure" },
-  "AWS::KMS::Key": { destination: "Infrastructure" },
-  "AWS::KMS::Alias": { destination: "Infrastructure" },
-  "AWS::SNS::Topic": { destination: "Infrastructure" },
-  "AWS::SQS::Queue": { destination: "Infrastructure" }
+  "AWS::SQS::QueuePolicy": { desination: "Policy" }
 };


### PR DESCRIPTION
We had `Template format error: Unresolved resource dependencies [ServerlessDeploymentBucket] in the Resources block of the template` issue when grouping some resources into `Infrastructure` . The [Infrastructure] manual grouping break the dependencies of resources. I remove the [Infrastructure] grouping and the issue is resolved.