### PR TITLE
fix: PD-4142 fix concurrency

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -23,6 +23,7 @@ functions:
     handler: functions/AutoRemediateOrchestrator.handler
     timeout: 10
     memorySize: 128
+    reservedConcurrency: 1
     events:
       - sqs:
           arn: !GetAtt

--- a/serverless.yml
+++ b/serverless.yml
@@ -15,7 +15,7 @@ provider:
 
 custom:
   splitStacks:
-    custom: stacks-map.js
+    custom: splitter.js
 
 functions:
 

--- a/splitter.js
+++ b/splitter.js
@@ -1,0 +1,21 @@
+module.exports = (resource, logicalId) => {
+  let destination;
+  switch (true) {
+    case logicalId.endsWith("Role"):
+      destination = "Role";
+      break;
+    case logicalId.endsWith("LambdaFunction"):
+      destination = "Function";
+      break;
+    case logicalId.endsWith("LogGroup"):
+      destination = "Log";
+      break;
+    case logicalId.includes("LambdaVersion"):
+      destination = "Version";
+      break;
+    default:
+      destination = "Infrastructure";
+      break;
+  }
+  return { destination };
+};

--- a/stacks-map.js
+++ b/stacks-map.js
@@ -1,8 +1,0 @@
-module.exports = {
-  "AWS::Lambda::Function": { destination: "Function" },
-  "AWS::IAM::Role": { destination: "Role" },
-  "AWS::Logs::LogGroup": { destination: "Log" },
-  "AWS::Lambda::Version": { desination: "Function" },
-  "AWS::S3::BucketPolicy": { desination: "Policy" },
-  "AWS::SQS::QueuePolicy": { desination: "Policy" }
-};


### PR DESCRIPTION
When there was large amount of auto remediation requests coming, we still can see the `OperationAborted` error. 
This change is to configure the `concurrency` of the Lambda Ochestrator to 1 to avoid the racing condition.