### PR TITLE
UNBREAKING CHANGE: remove jfrog from package-lock.json

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+registry=https://registry.npmjs.org/
+always-auth=false

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
     },
     "node_modules/@aws-crypto/crc32": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
@@ -63,7 +63,7 @@
     },
     "node_modules/@aws-crypto/crc32c": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
       "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
@@ -73,7 +73,7 @@
     },
     "node_modules/@aws-crypto/ie11-detection": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "dependencies": {
         "tslib": "^1.11.1"
@@ -81,7 +81,7 @@
     },
     "node_modules/@aws-crypto/sha1-browser": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
       "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
@@ -95,7 +95,7 @@
     },
     "node_modules/@aws-crypto/sha256-browser": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "dependencies": {
         "@aws-crypto/ie11-detection": "^3.0.0",
@@ -110,7 +110,7 @@
     },
     "node_modules/@aws-crypto/sha256-js": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "dependencies": {
         "@aws-crypto/util": "^3.0.0",
@@ -120,7 +120,7 @@
     },
     "node_modules/@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "dependencies": {
         "tslib": "^1.11.1"
@@ -128,7 +128,7 @@
     },
     "node_modules/@aws-crypto/util": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/util/-/util-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "dependencies": {
         "@aws-sdk/types": "^3.222.0",
@@ -138,7 +138,7 @@
     },
     "node_modules/@aws-sdk/client-cloudformation": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-cloudformation/-/client-cloudformation-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.490.0.tgz",
       "integrity": "sha512-WtHIxAAEpWID4u3UeZSq+wE2fXgSi04LaqQ/ZDtCJ4UbR/ml5y05lX0HCXdkPJbqbmBXzoZRPKUPGicJ03Hy0w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -191,7 +191,7 @@
     },
     "node_modules/@aws-sdk/client-cloudformation/node_modules/@aws-sdk/client-sts": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
       "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -241,12 +241,12 @@
     },
     "node_modules/@aws-sdk/client-cloudformation/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-cloudtrail": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.490.0.tgz",
       "integrity": "sha512-Tmf87vXK03P3EqTiot4MnkfK6yKpAaNFmbrvU75+pDZ5RrsevBPv/Mpb+B4snVxOvUKIaVvMEcTEl8TXRO/GAA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -296,7 +296,7 @@
     },
     "node_modules/@aws-sdk/client-cloudtrail/node_modules/@aws-sdk/client-sts": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
       "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -346,12 +346,12 @@
     },
     "node_modules/@aws-sdk/client-cloudtrail/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-config-service": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-config-service/-/client-config-service-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-config-service/-/client-config-service-3.490.0.tgz",
       "integrity": "sha512-k4k/peTSnb9sOGBUDmCYHb/oxeKSKOT6oPdH5anp+bqZxlivSaRB6vN81P/pzdJC6Y6pNLAV/X3r8qb16GX3pQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -401,7 +401,7 @@
     },
     "node_modules/@aws-sdk/client-config-service/node_modules/@aws-sdk/client-sts": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
       "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -451,12 +451,12 @@
     },
     "node_modules/@aws-sdk/client-config-service/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-ec2": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-ec2/-/client-ec2-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.496.0.tgz",
       "integrity": "sha512-6mLG3EKmo2kaBmSplhtN0HnbvRHdRMuMCnugIiMzWzIZ71stbQ7Cz/UiPbBX1M8eaAViJuX+mA4o18Lfvj8yvA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -510,7 +510,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -557,7 +557,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -573,7 +573,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -587,7 +587,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -607,7 +607,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -628,7 +628,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -643,7 +643,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -660,7 +660,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -674,7 +674,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -688,7 +688,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -701,7 +701,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -715,7 +715,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -730,7 +730,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -746,7 +746,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -793,7 +793,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -805,7 +805,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -819,7 +819,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -830,7 +830,7 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -852,12 +852,12 @@
     },
     "node_modules/@aws-sdk/client-ec2/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-guardduty": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-guardduty/-/client-guardduty-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-guardduty/-/client-guardduty-3.496.0.tgz",
       "integrity": "sha512-fpaD9m36LTXiIjFXw8WXaCB5Lkh6NQH1sj+O3/8f4GWzDs1flFaDtJ1+AqYlkfcr1iEHCaJjuIJ8zUMclj9u3Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -908,7 +908,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -955,7 +955,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -971,7 +971,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -985,7 +985,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -1005,7 +1005,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -1026,7 +1026,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1041,7 +1041,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -1058,7 +1058,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1072,7 +1072,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1086,7 +1086,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1099,7 +1099,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1113,7 +1113,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/middleware-signing": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
       "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1130,7 +1130,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1145,7 +1145,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1161,7 +1161,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -1208,7 +1208,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -1220,7 +1220,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1234,7 +1234,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1245,7 +1245,7 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1267,12 +1267,12 @@
     },
     "node_modules/@aws-sdk/client-guardduty/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-iam": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-iam/-/client-iam-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.490.0.tgz",
       "integrity": "sha512-jMGKufnBd26DRcwWvv4MxR+mXgLh7KezpxZrT16lxR88U5sD8gOXohj1I1t5f8W8ihON1Ml8EJU++ui6KAowMw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -1324,7 +1324,7 @@
     },
     "node_modules/@aws-sdk/client-iam/node_modules/@aws-sdk/client-sts": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
       "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -1374,12 +1374,12 @@
     },
     "node_modules/@aws-sdk/client-iam/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-kinesis": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-kinesis/-/client-kinesis-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.496.0.tgz",
       "integrity": "sha512-GHFV9XGfFQXjGRlU17XtRkkvR+IUDRB5qaUqDb8hsCEwC4SUtGk4xK1LBI7lf260fZQar8sKxCpi6xhj67QlQQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -1433,7 +1433,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -1480,7 +1480,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -1496,7 +1496,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1510,7 +1510,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -1530,7 +1530,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -1551,7 +1551,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1566,7 +1566,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -1583,7 +1583,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1597,7 +1597,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1611,7 +1611,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1624,7 +1624,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1638,7 +1638,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-signing": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
       "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1655,7 +1655,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1670,7 +1670,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1686,7 +1686,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -1733,7 +1733,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -1745,7 +1745,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1759,7 +1759,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1770,7 +1770,7 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1792,12 +1792,12 @@
     },
     "node_modules/@aws-sdk/client-kinesis/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-kms": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-kms/-/client-kms-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.496.0.tgz",
       "integrity": "sha512-LJKekt6zLxoaDyQN8HPJyuxxMja31w0+yaeafrqQqO5RX75YpWm8gM4aLk51C9uO5p4NGCQTrccdhhjbNXWz/w==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -1847,7 +1847,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -1894,7 +1894,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -1910,7 +1910,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1924,7 +1924,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -1944,7 +1944,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -1965,7 +1965,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -1980,7 +1980,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -1997,7 +1997,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2011,7 +2011,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2025,7 +2025,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2038,7 +2038,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2052,7 +2052,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-signing": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
       "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2069,7 +2069,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2084,7 +2084,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2100,7 +2100,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -2147,7 +2147,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -2159,7 +2159,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2173,7 +2173,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2184,7 +2184,7 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2206,12 +2206,12 @@
     },
     "node_modules/@aws-sdk/client-kms/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-lambda": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-lambda/-/client-lambda-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.496.0.tgz",
       "integrity": "sha512-HsypBL5BIxK/2MPZ7mKsAypEn98Jws5kWKmOzVACOvboyvpgaDgrFqubNWkHPWlwg8vJBjixhrQpHxp1vzeVUw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -2266,7 +2266,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -2313,7 +2313,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -2329,7 +2329,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2343,7 +2343,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -2363,7 +2363,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -2384,7 +2384,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2399,7 +2399,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -2416,7 +2416,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2430,7 +2430,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2444,7 +2444,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2457,7 +2457,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2471,7 +2471,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-signing": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
       "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2488,7 +2488,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2503,7 +2503,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2519,7 +2519,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -2566,7 +2566,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -2578,7 +2578,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2592,7 +2592,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2603,7 +2603,7 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2625,12 +2625,12 @@
     },
     "node_modules/@aws-sdk/client-lambda/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-organizations": {
       "version": "3.497.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-organizations/-/client-organizations-3.497.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.497.0.tgz",
       "integrity": "sha512-A3vsA7iXr5Uu3+V2pDHJ0JraelNNpa4lRqKJWYL8I5hWU2VTfz5hHK+A9+YVs4xnTfn33w4zUmUBn8IbCc26Lw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -2680,7 +2680,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -2727,7 +2727,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -2743,7 +2743,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2757,7 +2757,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -2777,7 +2777,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -2798,7 +2798,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2813,7 +2813,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -2830,7 +2830,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2844,7 +2844,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2858,7 +2858,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2871,7 +2871,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2885,7 +2885,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/middleware-signing": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
       "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2902,7 +2902,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2917,7 +2917,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -2933,7 +2933,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -2980,7 +2980,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -2992,7 +2992,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3006,7 +3006,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3017,7 +3017,7 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3039,12 +3039,12 @@
     },
     "node_modules/@aws-sdk/client-organizations/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-rds": {
       "version": "3.497.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-rds/-/client-rds-3.497.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rds/-/client-rds-3.497.0.tgz",
       "integrity": "sha512-W0rPMRlcy4cbg68D/XmtZQy5DWBkjsQyhrngPKx+4fNpwghnaTom0CDf6pk/xq1IOvY4aGJ6CM3uAoUs9pkuZQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -3097,7 +3097,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -3144,7 +3144,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -3160,7 +3160,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3174,7 +3174,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -3194,7 +3194,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -3215,7 +3215,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3230,7 +3230,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -3247,7 +3247,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3261,7 +3261,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3275,7 +3275,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3288,7 +3288,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3302,7 +3302,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3317,7 +3317,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3333,7 +3333,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -3380,7 +3380,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -3392,7 +3392,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3406,7 +3406,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3417,7 +3417,7 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3439,12 +3439,12 @@
     },
     "node_modules/@aws-sdk/client-rds/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-redshift": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-redshift/-/client-redshift-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-redshift/-/client-redshift-3.496.0.tgz",
       "integrity": "sha512-pg520g/QHpFbwjK0HnlMmHcbi0N1N35dFxyzQg6OIXQV5v4E0omg49FnB+uLo5AYRaJ2YvdT7Vle9fda4gJ0bg==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -3496,7 +3496,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -3543,7 +3543,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -3559,7 +3559,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3573,7 +3573,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -3593,7 +3593,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -3614,7 +3614,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3629,7 +3629,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -3646,7 +3646,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3660,7 +3660,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3674,7 +3674,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3687,7 +3687,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3701,7 +3701,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/middleware-signing": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
       "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3718,7 +3718,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3733,7 +3733,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3749,7 +3749,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -3796,7 +3796,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -3808,7 +3808,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3822,7 +3822,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3833,7 +3833,7 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -3855,12 +3855,12 @@
     },
     "node_modules/@aws-sdk/client-redshift/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-s3": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-s3/-/client-s3-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.490.0.tgz",
       "integrity": "sha512-fBj3CJ3+5R+l/sc93Z9mKw8gM2b9K6vEhC9qSCG2XNymLd9YqlRft1peQ7VymrWywAHX3Koz1GCUrFEVNONiMw==",
       "dependencies": {
         "@aws-crypto/sha1-browser": "3.0.0",
@@ -3928,7 +3928,7 @@
     },
     "node_modules/@aws-sdk/client-s3/node_modules/@aws-sdk/client-sts": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
       "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -3978,12 +3978,12 @@
     },
     "node_modules/@aws-sdk/client-s3/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-sqs": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sqs/-/client-sqs-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.496.0.tgz",
       "integrity": "sha512-Fo/Kz9nEbGso/lJ7piPGyvSeGWRwgPrC5vgKh0D8cwVhBY2LmRVHfBtJ1p42q0TUJY6i/1TOFxXZdvavYcwb9Q==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -4035,7 +4035,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -4082,7 +4082,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -4098,7 +4098,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4112,7 +4112,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -4132,7 +4132,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -4153,7 +4153,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4168,7 +4168,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -4185,7 +4185,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4199,7 +4199,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4213,7 +4213,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4226,7 +4226,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4240,7 +4240,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4255,7 +4255,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4271,7 +4271,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -4318,7 +4318,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -4330,7 +4330,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4344,7 +4344,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4355,7 +4355,7 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4377,12 +4377,12 @@
     },
     "node_modules/@aws-sdk/client-sqs/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-sso": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.490.0.tgz",
       "integrity": "sha512-yfxoHmCL1w/IKmFRfzCxdVCQrGlSQf4eei9iVEm5oi3iE8REFyPj3o/BmKQEHG3h2ITK5UbdYDb5TY4xoYHsyA==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -4429,12 +4429,12 @@
     },
     "node_modules/@aws-sdk/client-sso/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/client-sts": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.496.0.tgz",
       "integrity": "sha512-3pSdqgegdwbK3CT1WvGHhA+Bf91R9cr8G1Ynp+iU2wZvy8ueJfMUk0NYfjo3EEv0YhSbMLKuduzZfvQHFHXYhw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -4484,7 +4484,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/client-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
       "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -4531,7 +4531,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/core": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
       "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
       "dependencies": {
         "@smithy/core": "^1.3.1",
@@ -4547,7 +4547,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
       "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4561,7 +4561,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
       "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -4581,7 +4581,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
       "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.496.0",
@@ -4602,7 +4602,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
       "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4617,7 +4617,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
       "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.496.0",
@@ -4634,7 +4634,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
       "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4648,7 +4648,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
       "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4662,7 +4662,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-logger": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
       "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4675,7 +4675,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
       "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4689,7 +4689,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
       "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4704,7 +4704,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
       "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4720,7 +4720,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/token-providers": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
       "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -4767,7 +4767,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -4779,7 +4779,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-endpoints": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
       "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4793,7 +4793,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
       "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4804,7 +4804,7 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
       "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -4826,12 +4826,12 @@
     },
     "node_modules/@aws-sdk/client-sts/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/core": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.490.0.tgz",
       "integrity": "sha512-TSBWkXtxMU7q1Zo6w3v5wIOr/sj7P5Jw3OyO7lJrFGsPsDC2xwpxkVqTesDxkzgMRypO52xjYEmveagn1xxBHg==",
       "dependencies": {
         "@smithy/core": "^1.2.2",
@@ -4847,12 +4847,12 @@
     },
     "node_modules/@aws-sdk/core/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-provider-env": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.489.0.tgz",
       "integrity": "sha512-5PqYsx9G5SB2tqPT9/z/u0EkF6D4wP6HTMWQs+DfMdmwXihrqQAgeYaTtV3KbXqb88p6sfacwxhUvE6+Rm494w==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -4866,12 +4866,12 @@
     },
     "node_modules/@aws-sdk/credential-provider-env/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.490.0.tgz",
       "integrity": "sha512-7m63zyCpVqj9FsoDxWMWWRvL6c7zZzOcXYkHZmHujVVlmAXH0RT/vkXFkYgt+Ku+ov+v5NQrzwO5TmVoRt6O8g==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.489.0",
@@ -4891,12 +4891,12 @@
     },
     "node_modules/@aws-sdk/credential-provider-ini/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-provider-node": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.490.0.tgz",
       "integrity": "sha512-Gh33u2O5Xbout8G3z/Z5H/CZzdG1ophxf/XS3iMFxA1cazQ7swY1UMmGvB7Lm7upvax5anXouItD1Ph3gzKc4w==",
       "dependencies": {
         "@aws-sdk/credential-provider-env": "3.489.0",
@@ -4917,12 +4917,12 @@
     },
     "node_modules/@aws-sdk/credential-provider-node/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-provider-process": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.489.0.tgz",
       "integrity": "sha512-3vKQYJZ5cZYjy0870CPmbmKRBgATw2xCygxhn4m4UDCjOXVXcGUtYD51DMWsvBo3S0W8kH+FIJV4yuEDMFqLFQ==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -4937,12 +4937,12 @@
     },
     "node_modules/@aws-sdk/credential-provider-process/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.490.0.tgz",
       "integrity": "sha512-3UUBUoPbFvT58IhS4Vb23omYj/QPNkjgxu9p9ruQ3KSjLkanI4w8t/l/jljA65q83P7CoLnM5UKG9L7RA8/V1Q==",
       "dependencies": {
         "@aws-sdk/client-sso": "3.490.0",
@@ -4959,12 +4959,12 @@
     },
     "node_modules/@aws-sdk/credential-provider-sso/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.489.0.tgz",
       "integrity": "sha512-mjIuE2Wg1H/ds0nXQ/7vfusEDudmdd8YzKZI1y5O4n60iZZtyB2RNIECtvLMx1EQAKclidY7/06qQkArrGau5Q==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -4978,12 +4978,12 @@
     },
     "node_modules/@aws-sdk/credential-provider-web-identity/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.489.0.tgz",
       "integrity": "sha512-6rJ5bpNMKo7sEKQ6p2DMbQwM+ahMYASRxfdyH7hs18blvlcS20H1RYpNmJMqPPjxMwUWruty2JPMIRl4DFcv8w==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5000,12 +5000,12 @@
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.489.0.tgz",
       "integrity": "sha512-2RZfnVZFaGHwzPDQJsyf9SXufu1gUd4VsMhm7dC7SWF85XmpDrozbFznS/tD22QdtyWjerLoydZJMq229hpPqg==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5019,12 +5019,12 @@
     },
     "node_modules/@aws-sdk/middleware-expect-continue/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.489.0.tgz",
       "integrity": "sha512-Cy3rBUMr4P7raxzrJFWNRshfKrKV2EojawaC9Bfk/T8aFlV+FmVrRg4ISAXMOfS5pfy3xfAbvkzjOaeqCsGfrA==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
@@ -5042,12 +5042,12 @@
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-host-header": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.489.0.tgz",
       "integrity": "sha512-Cl7HJ1jhOfllwf0CRx1eB4ypRGMqdGKWpc0eSTXty7wWSvCdMZUhwfjQqu2bIOIlgYxg/gFu6TVmVZ6g4O8PlA==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5061,12 +5061,12 @@
     },
     "node_modules/@aws-sdk/middleware-host-header/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.489.0.tgz",
       "integrity": "sha512-NIVr+kHR2N6gxFeE3TNw2mEBxgj0N9xXBLy3dNYMMlAUvQlT/0z9HlC9+3XqcTS/Z5ElF/+pei6nqXTVt0He9A==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5079,12 +5079,12 @@
     },
     "node_modules/@aws-sdk/middleware-location-constraint/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-logger": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.489.0.tgz",
       "integrity": "sha512-+EVDnWese61MdImcBNAgz/AhTcIZJaska/xsU3GWU9CP905x4a4qZdB7fExFMDu1Jlz5pJqNteFYYHCFMJhHfg==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5097,12 +5097,12 @@
     },
     "node_modules/@aws-sdk/middleware-logger/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.489.0.tgz",
       "integrity": "sha512-m4rU+fTzziQcu9DKjRNZ4nQlXENEd2ZnJblJV4ONdWqqEjbmOgOj3P6aCCQlJdIbzuNvX1FBOZ5tY59ZpERo7Q==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5116,12 +5116,12 @@
     },
     "node_modules/@aws-sdk/middleware-recursion-detection/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.496.0.tgz",
       "integrity": "sha512-fk3ZdXPujb1FTuxIRUudN4yM+/gjjzv155U9pW6yIaAAzEK/CRV0SkbFP6KDkCClqMCmoYjTBzFB5ZY4gQnAhQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -5139,7 +5139,7 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -5151,12 +5151,12 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-ec2/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-sdk-rds": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.496.0.tgz",
       "integrity": "sha512-eKJzcMTSC5aC3SWY16CwTWkwDbdt1QKrFDAS+sJkoWJ9WOBKR+H0zmRD2WHlSV4xytuaFt03YDKnmKs9LAxBiA==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -5173,7 +5173,7 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -5185,12 +5185,12 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-rds/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.489.0.tgz",
       "integrity": "sha512-/GGASx7mK9qEgy1znvleYMZKVqm3sOdGghqKdy2zgoGcH2jH+fZrLM0lDMT9bvdITmOCbJJs2rVHP3xm/ZWcXg==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5209,12 +5209,12 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.496.0.tgz",
       "integrity": "sha512-CkZLaKeplUcir+MFgYi+xVs67H6pgnyNIcS6PZA9fQq14ERVhiKoXAhPLaAbBt7JDScCgtoD1ZsPvSHMRSi18w==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -5229,7 +5229,7 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -5241,12 +5241,12 @@
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-signing": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.489.0.tgz",
       "integrity": "sha512-rlHcWYZn6Ym3v/u0DvKNDiD7ogIzEsHlerm0lowTiQbszkFobOiUClRTALwvsUZdAAztl706qO1OKbnGnD6Ubw==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5263,12 +5263,12 @@
     },
     "node_modules/@aws-sdk/middleware-signing/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-ssec": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-ssec/-/middleware-ssec-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.489.0.tgz",
       "integrity": "sha512-5RQg8dqERAmi1OfVEV9fbTA5NKmcvKDYP79YtH08IEFIsHWU1Y5NoqL7mXkkNyBrJNBVyasYijAbTzOuM707eg==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5281,12 +5281,12 @@
     },
     "node_modules/@aws-sdk/middleware-ssec/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.489.0.tgz",
       "integrity": "sha512-M54Cv2fAN3GGgdfUjLtZ4wFUIrfM/ivbXv4DgpcNsacEQ2g4H+weQgKp41X7XZW8MWAzl+k1zJaryK69RYNQkQ==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5301,12 +5301,12 @@
     },
     "node_modules/@aws-sdk/middleware-user-agent/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/region-config-resolver": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.489.0.tgz",
       "integrity": "sha512-UvrnB78XTz9ddby7mr0vuUHn2MO3VTjzaIu+GQhyedMGQU0QlIQrYOlzbbu4LC5rL1O8FxFLUxRe/AAjgwyuGw==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5322,12 +5322,12 @@
     },
     "node_modules/@aws-sdk/region-config-resolver/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.489.0.tgz",
       "integrity": "sha512-kYFM7Opu36EkFlzXdVNOBFpQApgnuaTu/U/qYhGyuzeD+HNnYgZEsd/tDro1DQ074jVy3GN9ttJSYxq5I4oTkA==",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "3.489.0",
@@ -5343,12 +5343,12 @@
     },
     "node_modules/@aws-sdk/signature-v4-multi-region/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/token-providers": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.489.0.tgz",
       "integrity": "sha512-hSgjB8CMQoA8EIQ0ripDjDtbBcWDSa+7vSBYPIzksyknaGERR/GUfGXLV2dpm5t17FgFG6irT5f3ZlBzarL8Dw==",
       "dependencies": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -5395,12 +5395,12 @@
     },
     "node_modules/@aws-sdk/token-providers/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/types": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.489.0.tgz",
       "integrity": "sha512-kcDtLfKog/p0tC4gAeqJqWxAiEzfe2LRPnKamvSG2Mjbthx4R/alE2dxyIq/wW+nvRv0fqR3OD5kD1+eVfdr/w==",
       "dependencies": {
         "@smithy/types": "^2.8.0",
@@ -5412,12 +5412,12 @@
     },
     "node_modules/@aws-sdk/types/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/util-arn-parser": {
       "version": "3.465.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-arn-parser/-/util-arn-parser-3.465.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.465.0.tgz",
       "integrity": "sha512-zOJ82vzDJFqBX9yZBlNeHHrul/kpx/DCoxzW5UBbZeb26kfV53QhMSoEmY8/lEbBqlqargJ/sgRC845GFhHNQw==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -5428,12 +5428,12 @@
     },
     "node_modules/@aws-sdk/util-arn-parser/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/util-endpoints": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.489.0.tgz",
       "integrity": "sha512-uGyG1u84ATX03mf7bT4xD9XD/vlYJGD5+RxMN/UpzeTfzXfh+jvCQWbOQ44z8ttFJWYQQqrLxkfpF/JgvALzLA==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5447,12 +5447,12 @@
     },
     "node_modules/@aws-sdk/util-endpoints/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/util-format-url": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-format-url/-/util-format-url-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.496.0.tgz",
       "integrity": "sha512-GYRqLEUVoIkD8+ULliODFWWRHGyjlanLCnj8faahZXUke6Ey32MG40RgPTu/2eFkUyS6U7sVdt7oLY8MIHShPQ==",
       "dependencies": {
         "@aws-sdk/types": "3.496.0",
@@ -5466,7 +5466,7 @@
     },
     "node_modules/@aws-sdk/util-format-url/node_modules/@aws-sdk/types": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
       "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -5478,12 +5478,12 @@
     },
     "node_modules/@aws-sdk/util-format-url/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/util-locate-window": {
       "version": "3.465.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-locate-window/-/util-locate-window-3.465.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.465.0.tgz",
       "integrity": "sha512-f+QNcWGswredzC1ExNAB/QzODlxwaTdXkNT5cvke2RLX8SFU5pYk6h4uCtWC0vWPELzOfMfloBrJefBzlarhsw==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -5494,12 +5494,12 @@
     },
     "node_modules/@aws-sdk/util-locate-window/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/util-retry": {
       "version": "3.374.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-retry/-/util-retry-3.374.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.374.0.tgz",
       "integrity": "sha512-0p/trhYU+Ys8j3vMnWCvAkSOL6JRMooV9dVlQ+o7EHbQs9kDtnyucMUHU09ahHSIPTA/n/013hv7bzIt3MyKQg==",
       "deprecated": "This package has moved to @smithy/util-retry",
       "dependencies": {
@@ -5512,7 +5512,7 @@
     },
     "node_modules/@aws-sdk/util-retry/node_modules/@smithy/service-error-classification": {
       "version": "1.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/service-error-classification/-/service-error-classification-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.1.0.tgz",
       "integrity": "sha512-OCTEeJ1igatd5kFrS2VDlYbainNNpf7Lj1siFOxnRWqYOP9oNvC5HOJBd3t+Z8MbrmehBtuDJ2QqeBsfeiNkww==",
       "engines": {
         "node": ">=14.0.0"
@@ -5520,7 +5520,7 @@
     },
     "node_modules/@aws-sdk/util-retry/node_modules/@smithy/util-retry": {
       "version": "1.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-retry/-/util-retry-1.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.1.0.tgz",
       "integrity": "sha512-ygQW5HBqYXpR3ua09UciS0sL7UGJzGiktrKkOuEJwARoUuzz40yaEGU6xd9Gs7KBmAaFC8gMfnghHtwZ2nyBCQ==",
       "dependencies": {
         "@smithy/service-error-classification": "^1.1.0",
@@ -5532,12 +5532,12 @@
     },
     "node_modules/@aws-sdk/util-retry/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.489.0.tgz",
       "integrity": "sha512-85B9KMsuMpAZauzWQ16r52ZBAHYnznW6BVitnBglsibN7oJKn10Hggt4QGuRhvQFCxQ8YhvBl7r+vQGFO4hxIw==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5548,12 +5548,12 @@
     },
     "node_modules/@aws-sdk/util-user-agent-browser/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.489.0.tgz",
       "integrity": "sha512-CYdkBHig8sFNc0dv11Ni9WXvZQHeI5+z77OrDHKkbidFx/V4BDTuwZw4K1vWg62pzFOEfzunJFiULRcDZWJR3w==",
       "dependencies": {
         "@aws-sdk/types": "3.489.0",
@@ -5575,12 +5575,12 @@
     },
     "node_modules/@aws-sdk/util-user-agent-node/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/util-utf8-browser": {
       "version": "3.259.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "dependencies": {
         "tslib": "^2.3.1"
@@ -5588,12 +5588,12 @@
     },
     "node_modules/@aws-sdk/util-utf8-browser/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@aws-sdk/xml-builder": {
       "version": "3.485.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/xml-builder/-/xml-builder-3.485.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.485.0.tgz",
       "integrity": "sha512-xQexPM6LINOIkf3NLFywplcbApifZRMWFN41TDWYSNgCUa5uC9fntfenw8N/HTx1n+McRCWSAFBTjDqY/2OLCQ==",
       "dependencies": {
         "@smithy/types": "^2.8.0",
@@ -5605,12 +5605,12 @@
     },
     "node_modules/@aws-sdk/xml-builder/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@babel/code-frame": {
       "version": "7.23.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
       "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
       "dependencies": {
@@ -5703,7 +5703,7 @@
     },
     "node_modules/@babel/helper-environment-visitor": {
       "version": "7.22.20",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
       "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true,
       "engines": {
@@ -5712,7 +5712,7 @@
     },
     "node_modules/@babel/helper-function-name": {
       "version": "7.23.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
       "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "dependencies": {
@@ -5725,7 +5725,7 @@
     },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.22.15",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
       "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "dependencies": {
@@ -5737,7 +5737,7 @@
     },
     "node_modules/@babel/helper-module-transforms": {
       "version": "7.23.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
       "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "dependencies": {
@@ -5756,7 +5756,7 @@
     },
     "node_modules/@babel/helper-plugin-utils": {
       "version": "7.22.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true,
       "engines": {
@@ -5765,7 +5765,7 @@
     },
     "node_modules/@babel/helper-simple-access": {
       "version": "7.22.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
       "dependencies": {
@@ -5777,7 +5777,7 @@
     },
     "node_modules/@babel/helper-split-export-declaration": {
       "version": "7.22.6",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "dependencies": {
@@ -5789,7 +5789,7 @@
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.23.4",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
       "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "dev": true,
       "engines": {
@@ -5798,7 +5798,7 @@
     },
     "node_modules/@babel/helper-validator-identifier": {
       "version": "7.22.20",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true,
       "engines": {
@@ -5807,7 +5807,7 @@
     },
     "node_modules/@babel/helper-validator-option": {
       "version": "7.23.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
       "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true,
       "engines": {
@@ -5827,7 +5827,7 @@
     },
     "node_modules/@babel/highlight": {
       "version": "7.23.4",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/highlight/-/highlight-7.23.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
       "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
       "dependencies": {
@@ -5841,7 +5841,7 @@
     },
     "node_modules/@babel/parser": {
       "version": "7.23.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/parser/-/parser-7.23.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
       "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
       "dev": true,
       "bin": {
@@ -5997,7 +5997,7 @@
     },
     "node_modules/@babel/template": {
       "version": "7.22.15",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/template/-/template-7.22.15.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
       "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "dependencies": {
@@ -6036,7 +6036,7 @@
     },
     "node_modules/@babel/types": {
       "version": "7.23.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/types/-/types-7.23.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
       "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
       "dev": true,
       "dependencies": {
@@ -6478,7 +6478,7 @@
     },
     "node_modules/@jest/expect-utils": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
       "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
       "dev": true,
       "dependencies": {
@@ -6490,7 +6490,7 @@
     },
     "node_modules/@jest/expect-utils/node_modules/jest-get-type": {
       "version": "28.0.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
       "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
       "dev": true,
       "engines": {
@@ -6638,7 +6638,7 @@
     },
     "node_modules/@jest/schemas": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@jest/schemas/-/schemas-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
       "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
       "dev": true,
       "dependencies": {
@@ -7336,7 +7336,7 @@
     },
     "node_modules/@sinclair/typebox": {
       "version": "0.24.51",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinclair/typebox/-/typebox-0.24.51.tgz",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
       "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
       "dev": true
     },
@@ -7372,13 +7372,13 @@
     },
     "node_modules/@sinonjs/text-encoding": {
       "version": "0.7.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "node_modules/@smithy/abort-controller": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
       "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7390,12 +7390,12 @@
     },
     "node_modules/@smithy/abort-controller/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/chunked-blob-reader": {
       "version": "2.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.1.0.tgz",
       "integrity": "sha512-meKoKCIXxixSGzUGVXGc1lnn6cEM21XzknDfUmHopPCaYSgt86w3gaJSua8Gr3VYcSkkMTW2MyAygTXprLEOZQ==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -7403,7 +7403,7 @@
     },
     "node_modules/@smithy/chunked-blob-reader-native": {
       "version": "2.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.1.0.tgz",
       "integrity": "sha512-r9fRVRvQXpuWZtHX3VNAP4PQoCXvRDqcwr15TbaKSdtEJ/f0IPHDQ+M2MOEsYt2234FkNqCzAqtmeJrjpNak2g==",
       "dependencies": {
         "@smithy/util-base64": "^2.1.0",
@@ -7412,17 +7412,17 @@
     },
     "node_modules/@smithy/chunked-blob-reader-native/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/chunked-blob-reader/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/config-resolver": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
       "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
       "dependencies": {
         "@smithy/node-config-provider": "^2.2.1",
@@ -7437,12 +7437,12 @@
     },
     "node_modules/@smithy/config-resolver/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/core": {
       "version": "1.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/core/-/core-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.1.tgz",
       "integrity": "sha512-tf+NIu9FkOh312b6M9G4D68is4Xr7qptzaZGZUREELF8ysE1yLKphqt7nsomjKZVwW7WE5pDDex9idowNGRQ/Q==",
       "dependencies": {
         "@smithy/middleware-endpoint": "^2.4.1",
@@ -7460,12 +7460,12 @@
     },
     "node_modules/@smithy/core/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/credential-provider-imds": {
       "version": "2.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
       "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
       "dependencies": {
         "@smithy/node-config-provider": "^2.2.1",
@@ -7480,12 +7480,12 @@
     },
     "node_modules/@smithy/credential-provider-imds/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/eventstream-codec": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
       "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
       "dependencies": {
         "@aws-crypto/crc32": "3.0.0",
@@ -7496,12 +7496,12 @@
     },
     "node_modules/@smithy/eventstream-codec/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/eventstream-serde-browser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.1.1.tgz",
       "integrity": "sha512-JvEdCmGlZUay5VtlT8/kdR6FlvqTDUiJecMjXsBb0+k1H/qc9ME5n2XKPo8q/MZwEIA1GmGgYMokKGjVvMiDow==",
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^2.1.1",
@@ -7514,12 +7514,12 @@
     },
     "node_modules/@smithy/eventstream-serde-browser/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.1.1.tgz",
       "integrity": "sha512-EqNqXYp3+dk//NmW3NAgQr9bEQ7fsu/CcxQmTiq07JlaIcne/CBWpMZETyXm9w5LXkhduBsdXdlMscfDUDn2fA==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7531,12 +7531,12 @@
     },
     "node_modules/@smithy/eventstream-serde-config-resolver/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/eventstream-serde-node": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.1.1.tgz",
       "integrity": "sha512-LF882q/aFidFNDX7uROAGxq3H0B7rjyPkV6QDn6/KDQ+CG7AFkRccjxRf1xqajq/Pe4bMGGr+VKAaoF6lELIQw==",
       "dependencies": {
         "@smithy/eventstream-serde-universal": "^2.1.1",
@@ -7549,12 +7549,12 @@
     },
     "node_modules/@smithy/eventstream-serde-node/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/eventstream-serde-universal": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.1.1.tgz",
       "integrity": "sha512-LR0mMT+XIYTxk4k2fIxEA1BPtW3685QlqufUEUAX1AJcfFfxNDKEvuCRZbO8ntJb10DrIFVJR9vb0MhDCi0sAQ==",
       "dependencies": {
         "@smithy/eventstream-codec": "^2.1.1",
@@ -7567,12 +7567,12 @@
     },
     "node_modules/@smithy/eventstream-serde-universal/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/fetch-http-handler": {
       "version": "2.4.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
       "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
       "dependencies": {
         "@smithy/protocol-http": "^3.1.1",
@@ -7584,12 +7584,12 @@
     },
     "node_modules/@smithy/fetch-http-handler/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/hash-blob-browser": {
       "version": "2.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/hash-blob-browser/-/hash-blob-browser-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.1.0.tgz",
       "integrity": "sha512-MVlH6algsOuEaK745oSoymk7Tusny7AqP2bQ1yPzxJiWpHirHnzEzYP/aqZaZ4gWdSLMFF65WOwL6q2ijuKVgA==",
       "dependencies": {
         "@smithy/chunked-blob-reader": "^2.1.0",
@@ -7600,12 +7600,12 @@
     },
     "node_modules/@smithy/hash-blob-browser/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/hash-node": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
       "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7619,12 +7619,12 @@
     },
     "node_modules/@smithy/hash-node/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/hash-stream-node": {
       "version": "2.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/hash-stream-node/-/hash-stream-node-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.1.0.tgz",
       "integrity": "sha512-qhgWuXt8sVcDKrFNBRQmcIo6wfzONdeKlKDLsau4kKZ7xlEHScgUFtsAHvspV8sVREJIeMbOq4oSFSVmzvOikQ==",
       "dependencies": {
         "@smithy/types": "^2.9.0",
@@ -7637,12 +7637,12 @@
     },
     "node_modules/@smithy/hash-stream-node/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/invalid-dependency": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
       "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7651,12 +7651,12 @@
     },
     "node_modules/@smithy/invalid-dependency/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/is-array-buffer": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
       "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -7667,12 +7667,12 @@
     },
     "node_modules/@smithy/is-array-buffer/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/md5-js": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/md5-js/-/md5-js-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.1.1.tgz",
       "integrity": "sha512-L3MbIYBIdLlT+MWTYrdVSv/dow1+6iZ1Ad7xS0OHxTTs17d753ZcpOV4Ro7M7tRAVWML/sg2IAp/zzCb6aAttg==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7682,12 +7682,12 @@
     },
     "node_modules/@smithy/md5-js/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/middleware-content-length": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
       "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
       "dependencies": {
         "@smithy/protocol-http": "^3.1.1",
@@ -7700,12 +7700,12 @@
     },
     "node_modules/@smithy/middleware-content-length/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/middleware-endpoint": {
       "version": "2.4.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
       "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
       "dependencies": {
         "@smithy/middleware-serde": "^2.1.1",
@@ -7722,12 +7722,12 @@
     },
     "node_modules/@smithy/middleware-endpoint/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/middleware-retry": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
       "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
       "dependencies": {
         "@smithy/node-config-provider": "^2.2.1",
@@ -7746,12 +7746,12 @@
     },
     "node_modules/@smithy/middleware-retry/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/middleware-serde": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
       "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7763,12 +7763,12 @@
     },
     "node_modules/@smithy/middleware-serde/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/middleware-stack": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
       "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7780,12 +7780,12 @@
     },
     "node_modules/@smithy/middleware-stack/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/node-config-provider": {
       "version": "2.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
       "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
       "dependencies": {
         "@smithy/property-provider": "^2.1.1",
@@ -7799,12 +7799,12 @@
     },
     "node_modules/@smithy/node-config-provider/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/node-http-handler": {
       "version": "2.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
       "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
       "dependencies": {
         "@smithy/abort-controller": "^2.1.1",
@@ -7819,12 +7819,12 @@
     },
     "node_modules/@smithy/node-http-handler/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/property-provider": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
       "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7836,12 +7836,12 @@
     },
     "node_modules/@smithy/property-provider/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/protocol-http": {
       "version": "3.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
       "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7853,12 +7853,12 @@
     },
     "node_modules/@smithy/protocol-http/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/querystring-builder": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
       "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7871,12 +7871,12 @@
     },
     "node_modules/@smithy/querystring-builder/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/querystring-parser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
       "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7888,12 +7888,12 @@
     },
     "node_modules/@smithy/querystring-parser/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/service-error-classification": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
       "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
       "dependencies": {
         "@smithy/types": "^2.9.1"
@@ -7904,7 +7904,7 @@
     },
     "node_modules/@smithy/shared-ini-file-loader": {
       "version": "2.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
       "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -7916,12 +7916,12 @@
     },
     "node_modules/@smithy/shared-ini-file-loader/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/signature-v4": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
       "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
       "dependencies": {
         "@smithy/eventstream-codec": "^2.1.1",
@@ -7939,12 +7939,12 @@
     },
     "node_modules/@smithy/signature-v4/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/smithy-client": {
       "version": "2.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
       "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
       "dependencies": {
         "@smithy/middleware-endpoint": "^2.4.1",
@@ -7960,12 +7960,12 @@
     },
     "node_modules/@smithy/smithy-client/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/types": {
       "version": "2.9.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/types/-/types-2.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
       "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -7976,12 +7976,12 @@
     },
     "node_modules/@smithy/types/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/url-parser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
       "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
       "dependencies": {
         "@smithy/querystring-parser": "^2.1.1",
@@ -7991,12 +7991,12 @@
     },
     "node_modules/@smithy/url-parser/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-base64": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
       "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.1.1",
@@ -8008,12 +8008,12 @@
     },
     "node_modules/@smithy/util-base64/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-body-length-browser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
       "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -8021,12 +8021,12 @@
     },
     "node_modules/@smithy/util-body-length-browser/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-body-length-node": {
       "version": "2.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
       "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -8037,12 +8037,12 @@
     },
     "node_modules/@smithy/util-body-length-node/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-buffer-from": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
       "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "dependencies": {
         "@smithy/is-array-buffer": "^2.1.1",
@@ -8054,12 +8054,12 @@
     },
     "node_modules/@smithy/util-buffer-from/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-config-provider": {
       "version": "2.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
       "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -8070,12 +8070,12 @@
     },
     "node_modules/@smithy/util-config-provider/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
       "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
       "dependencies": {
         "@smithy/property-provider": "^2.1.1",
@@ -8090,12 +8090,12 @@
     },
     "node_modules/@smithy/util-defaults-mode-browser/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-defaults-mode-node": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.1.1.tgz",
       "integrity": "sha512-tYVrc+w+jSBfBd267KDnvSGOh4NMz+wVH7v4CClDbkdPfnjvImBZsOURncT5jsFwR9KCuDyPoSZq4Pa6+eCUrA==",
       "dependencies": {
         "@smithy/config-resolver": "^2.1.1",
@@ -8112,12 +8112,12 @@
     },
     "node_modules/@smithy/util-defaults-mode-node/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-endpoints": {
       "version": "1.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
       "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
       "dependencies": {
         "@smithy/node-config-provider": "^2.2.1",
@@ -8130,12 +8130,12 @@
     },
     "node_modules/@smithy/util-endpoints/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-hex-encoding": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
       "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -8146,12 +8146,12 @@
     },
     "node_modules/@smithy/util-hex-encoding/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-middleware": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
       "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
       "dependencies": {
         "@smithy/types": "^2.9.1",
@@ -8163,12 +8163,12 @@
     },
     "node_modules/@smithy/util-middleware/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-retry": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
       "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
       "dependencies": {
         "@smithy/service-error-classification": "^2.1.1",
@@ -8181,12 +8181,12 @@
     },
     "node_modules/@smithy/util-retry/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-stream": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
       "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
       "dependencies": {
         "@smithy/fetch-http-handler": "^2.4.1",
@@ -8204,12 +8204,12 @@
     },
     "node_modules/@smithy/util-stream/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-uri-escape": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
       "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
       "dependencies": {
         "tslib": "^2.5.0"
@@ -8220,12 +8220,12 @@
     },
     "node_modules/@smithy/util-uri-escape/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-utf8": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
       "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
       "dependencies": {
         "@smithy/util-buffer-from": "^2.1.1",
@@ -8237,12 +8237,12 @@
     },
     "node_modules/@smithy/util-utf8/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@smithy/util-waiter": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
       "integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
       "dependencies": {
         "@smithy/abort-controller": "^2.1.1",
@@ -8255,7 +8255,7 @@
     },
     "node_modules/@smithy/util-waiter/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/@szmarczak/http-timer": {
@@ -8379,7 +8379,7 @@
     },
     "node_modules/@types/jest": {
       "version": "28.1.8",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@types/jest/-/jest-28.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
       "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dev": true,
       "dependencies": {
@@ -8389,7 +8389,7 @@
     },
     "node_modules/@types/jest/node_modules/@jest/types": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@jest/types/-/types-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
       "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
       "dev": true,
       "dependencies": {
@@ -8406,7 +8406,7 @@
     },
     "node_modules/@types/jest/node_modules/@types/yargs": {
       "version": "17.0.32",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@types/yargs/-/yargs-17.0.32.tgz",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
       "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
       "dev": true,
       "dependencies": {
@@ -8415,7 +8415,7 @@
     },
     "node_modules/@types/jest/node_modules/ansi-regex": {
       "version": "5.0.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
       "engines": {
@@ -8424,7 +8424,7 @@
     },
     "node_modules/@types/jest/node_modules/ansi-styles": {
       "version": "4.3.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
       "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
@@ -8436,7 +8436,7 @@
     },
     "node_modules/@types/jest/node_modules/braces": {
       "version": "3.0.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/braces/-/braces-3.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
       "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
       "dev": true,
       "dependencies": {
@@ -8448,7 +8448,7 @@
     },
     "node_modules/@types/jest/node_modules/chalk": {
       "version": "4.1.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/chalk/-/chalk-4.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
@@ -8461,7 +8461,7 @@
     },
     "node_modules/@types/jest/node_modules/ci-info": {
       "version": "3.9.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/ci-info/-/ci-info-3.9.0.tgz",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
       "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
       "dev": true,
       "engines": {
@@ -8470,7 +8470,7 @@
     },
     "node_modules/@types/jest/node_modules/color-convert": {
       "version": "2.0.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/color-convert/-/color-convert-2.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
       "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
       "dev": true,
       "dependencies": {
@@ -8482,13 +8482,13 @@
     },
     "node_modules/@types/jest/node_modules/color-name": {
       "version": "1.1.4",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/color-name/-/color-name-1.1.4.tgz",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
     },
     "node_modules/@types/jest/node_modules/diff-sequences": {
       "version": "28.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/diff-sequences/-/diff-sequences-28.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
       "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
       "dev": true,
       "engines": {
@@ -8497,7 +8497,7 @@
     },
     "node_modules/@types/jest/node_modules/expect": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/expect/-/expect-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
       "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
       "dev": true,
       "dependencies": {
@@ -8513,7 +8513,7 @@
     },
     "node_modules/@types/jest/node_modules/fill-range": {
       "version": "7.0.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/fill-range/-/fill-range-7.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
       "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
       "dev": true,
       "dependencies": {
@@ -8525,7 +8525,7 @@
     },
     "node_modules/@types/jest/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
@@ -8534,7 +8534,7 @@
     },
     "node_modules/@types/jest/node_modules/is-number": {
       "version": "7.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/is-number/-/is-number-7.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
       "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
       "dev": true,
       "engines": {
@@ -8543,7 +8543,7 @@
     },
     "node_modules/@types/jest/node_modules/jest-diff": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-diff/-/jest-diff-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
       "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
       "dev": true,
       "dependencies": {
@@ -8558,7 +8558,7 @@
     },
     "node_modules/@types/jest/node_modules/jest-get-type": {
       "version": "28.0.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-get-type/-/jest-get-type-28.0.2.tgz",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
       "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
       "dev": true,
       "engines": {
@@ -8567,7 +8567,7 @@
     },
     "node_modules/@types/jest/node_modules/jest-matcher-utils": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
       "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
       "dev": true,
       "dependencies": {
@@ -8582,7 +8582,7 @@
     },
     "node_modules/@types/jest/node_modules/jest-message-util": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-message-util/-/jest-message-util-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
       "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
       "dev": true,
       "dependencies": {
@@ -8602,7 +8602,7 @@
     },
     "node_modules/@types/jest/node_modules/jest-util": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-util/-/jest-util-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
       "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
       "dev": true,
       "dependencies": {
@@ -8619,7 +8619,7 @@
     },
     "node_modules/@types/jest/node_modules/micromatch": {
       "version": "4.0.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/micromatch/-/micromatch-4.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
       "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
       "dev": true,
       "dependencies": {
@@ -8632,7 +8632,7 @@
     },
     "node_modules/@types/jest/node_modules/pretty-format": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/pretty-format/-/pretty-format-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
       "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
       "dev": true,
       "dependencies": {
@@ -8647,7 +8647,7 @@
     },
     "node_modules/@types/jest/node_modules/pretty-format/node_modules/ansi-styles": {
       "version": "5.2.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "engines": {
@@ -8656,13 +8656,13 @@
     },
     "node_modules/@types/jest/node_modules/react-is": {
       "version": "18.2.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/react-is/-/react-is-18.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
     "node_modules/@types/jest/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
@@ -8674,7 +8674,7 @@
     },
     "node_modules/@types/jest/node_modules/to-regex-range": {
       "version": "5.0.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
       "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
       "dev": true,
       "dependencies": {
@@ -8746,7 +8746,7 @@
     },
     "node_modules/@types/sinon": {
       "version": "10.0.20",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@types/sinon/-/sinon-10.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
       "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
       "dev": true,
       "dependencies": {
@@ -8755,7 +8755,7 @@
     },
     "node_modules/@types/sinonjs__fake-timers": {
       "version": "8.1.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true
     },
@@ -9313,7 +9313,7 @@
     },
     "node_modules/aws-sdk-client-mock": {
       "version": "3.0.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.1.tgz",
       "integrity": "sha512-9VAzJLl8mz99KP9HjOm/93d8vznRRUTpJooPBOunRdUAnVYopCe9xmMuu7eVemu8fQ+w6rP7o5bBK1kAFkB2KQ==",
       "dev": true,
       "dependencies": {
@@ -9324,7 +9324,7 @@
     },
     "node_modules/aws-sdk-client-mock-jest": {
       "version": "3.0.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/aws-sdk-client-mock-jest/-/aws-sdk-client-mock-jest-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock-jest/-/aws-sdk-client-mock-jest-3.0.1.tgz",
       "integrity": "sha512-eT0i+XkvitMt7ml2LVUayVd6oiFO7SqLQBEbRId094fs2qlWlL+Png0WuOFVCIcTZgjoK5v81UnKSLwFbbpWqA==",
       "dev": true,
       "dependencies": {
@@ -9337,13 +9337,13 @@
     },
     "node_modules/aws-sdk-client-mock-jest/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
     "node_modules/aws-sdk-client-mock/node_modules/@sinonjs/commons": {
       "version": "3.0.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/commons/-/commons-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
       "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
       "dev": true,
       "dependencies": {
@@ -9352,7 +9352,7 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/@sinonjs/fake-timers": {
       "version": "10.3.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
       "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
       "dev": true,
       "dependencies": {
@@ -9361,7 +9361,7 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/@sinonjs/samsam": {
       "version": "8.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
       "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
       "dev": true,
       "dependencies": {
@@ -9372,7 +9372,7 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/@sinonjs/samsam/node_modules/@sinonjs/commons": {
       "version": "2.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/commons/-/commons-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
       "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
       "dev": true,
       "dependencies": {
@@ -9381,7 +9381,7 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/diff": {
       "version": "5.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/diff/-/diff-5.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
       "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
       "dev": true,
       "engines": {
@@ -9390,7 +9390,7 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/has-flag": {
       "version": "4.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/has-flag/-/has-flag-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true,
       "engines": {
@@ -9399,13 +9399,13 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/just-extend": {
       "version": "6.2.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/just-extend/-/just-extend-6.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
       "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
       "dev": true
     },
     "node_modules/aws-sdk-client-mock/node_modules/nise": {
       "version": "5.1.7",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/nise/-/nise-5.1.7.tgz",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.7.tgz",
       "integrity": "sha512-wWtNUhkT7k58uvWTB/Gy26eA/EJKtPZFVAhEilN5UYVmmGRYOURbejRUyKm0Uu9XVEW7K5nBOZfR8VMB4QR2RQ==",
       "dev": true,
       "dependencies": {
@@ -9418,7 +9418,7 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/nise/node_modules/@sinonjs/fake-timers": {
       "version": "11.2.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
       "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
       "dev": true,
       "dependencies": {
@@ -9427,13 +9427,13 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/path-to-regexp": {
       "version": "6.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
       "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
       "dev": true
     },
     "node_modules/aws-sdk-client-mock/node_modules/sinon": {
       "version": "16.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/sinon/-/sinon-16.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
       "integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
       "dev": true,
       "dependencies": {
@@ -9447,7 +9447,7 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/supports-color": {
       "version": "7.2.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/supports-color/-/supports-color-7.2.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
       "dev": true,
       "dependencies": {
@@ -9459,7 +9459,7 @@
     },
     "node_modules/aws-sdk-client-mock/node_modules/tslib": {
       "version": "2.6.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
       "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
       "dev": true
     },
@@ -9751,7 +9751,7 @@
     },
     "node_modules/bowser": {
       "version": "2.11.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/bowser/-/bowser-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/brace-expansion": {
@@ -10036,7 +10036,7 @@
     },
     "node_modules/chalk": {
       "version": "2.4.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/chalk/-/chalk-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "dependencies": {
@@ -12676,7 +12676,7 @@
     },
     "node_modules/fast-xml-parser": {
       "version": "4.2.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "dependencies": {
         "strnum": "^1.0.5"
@@ -13080,7 +13080,7 @@
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
@@ -13446,7 +13446,7 @@
     },
     "node_modules/hasown": {
       "version": "2.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/hasown/-/hasown-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
       "dev": true,
       "dependencies": {
@@ -14126,7 +14126,7 @@
     },
     "node_modules/is-core-module": {
       "version": "2.13.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/is-core-module/-/is-core-module-2.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dev": true,
       "dependencies": {
@@ -16525,7 +16525,7 @@
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
@@ -19639,7 +19639,7 @@
     },
     "node_modules/semver": {
       "version": "6.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true,
       "bin": {
@@ -20878,7 +20878,7 @@
     },
     "node_modules/strnum": {
       "version": "1.0.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/strnum/-/strnum-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "node_modules/strtok3": {
@@ -20954,7 +20954,7 @@
     },
     "node_modules/supports-color": {
       "version": "5.5.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "dependencies": {
@@ -22135,7 +22135,7 @@
   "dependencies": {
     "@aws-crypto/crc32": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
       "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
       "requires": {
         "@aws-crypto/util": "^3.0.0",
@@ -22145,7 +22145,7 @@
     },
     "@aws-crypto/crc32c": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-3.0.0.tgz",
       "integrity": "sha512-ENNPPManmnVJ4BTXlOjAgD7URidbAznURqD0KvfREyc4o20DPYdEldU1f5cQ7Jbj0CJJSPaMIk/9ZshdB3210w==",
       "requires": {
         "@aws-crypto/util": "^3.0.0",
@@ -22155,7 +22155,7 @@
     },
     "@aws-crypto/ie11-detection": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
       "integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
       "requires": {
         "tslib": "^1.11.1"
@@ -22163,7 +22163,7 @@
     },
     "@aws-crypto/sha1-browser": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-3.0.0.tgz",
       "integrity": "sha512-NJth5c997GLHs6nOYTzFKTbYdMNA6/1XlKVgnZoaZcQ7z7UJlOgj2JdbHE8tiYLS3fzXNCguct77SPGat2raSw==",
       "requires": {
         "@aws-crypto/ie11-detection": "^3.0.0",
@@ -22177,7 +22177,7 @@
     },
     "@aws-crypto/sha256-browser": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
       "integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
       "requires": {
         "@aws-crypto/ie11-detection": "^3.0.0",
@@ -22192,7 +22192,7 @@
     },
     "@aws-crypto/sha256-js": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
       "integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
       "requires": {
         "@aws-crypto/util": "^3.0.0",
@@ -22202,7 +22202,7 @@
     },
     "@aws-crypto/supports-web-crypto": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
       "integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
       "requires": {
         "tslib": "^1.11.1"
@@ -22210,7 +22210,7 @@
     },
     "@aws-crypto/util": {
       "version": "3.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-crypto/util/-/util-3.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
       "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
       "requires": {
         "@aws-sdk/types": "^3.222.0",
@@ -22220,7 +22220,7 @@
     },
     "@aws-sdk/client-cloudformation": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-cloudformation/-/client-cloudformation-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudformation/-/client-cloudformation-3.490.0.tgz",
       "integrity": "sha512-WtHIxAAEpWID4u3UeZSq+wE2fXgSi04LaqQ/ZDtCJ4UbR/ml5y05lX0HCXdkPJbqbmBXzoZRPKUPGicJ03Hy0w==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -22270,7 +22270,7 @@
       "dependencies": {
         "@aws-sdk/client-sts": {
           "version": "3.490.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
           "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -22317,14 +22317,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-cloudtrail": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cloudtrail/-/client-cloudtrail-3.490.0.tgz",
       "integrity": "sha512-Tmf87vXK03P3EqTiot4MnkfK6yKpAaNFmbrvU75+pDZ5RrsevBPv/Mpb+B4snVxOvUKIaVvMEcTEl8TXRO/GAA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -22371,7 +22371,7 @@
       "dependencies": {
         "@aws-sdk/client-sts": {
           "version": "3.490.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
           "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -22418,14 +22418,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-config-service": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-config-service/-/client-config-service-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-config-service/-/client-config-service-3.490.0.tgz",
       "integrity": "sha512-k4k/peTSnb9sOGBUDmCYHb/oxeKSKOT6oPdH5anp+bqZxlivSaRB6vN81P/pzdJC6Y6pNLAV/X3r8qb16GX3pQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -22472,7 +22472,7 @@
       "dependencies": {
         "@aws-sdk/client-sts": {
           "version": "3.490.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
           "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -22519,14 +22519,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-ec2": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-ec2/-/client-ec2-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-ec2/-/client-ec2-3.496.0.tgz",
       "integrity": "sha512-6mLG3EKmo2kaBmSplhtN0HnbvRHdRMuMCnugIiMzWzIZ71stbQ7Cz/UiPbBX1M8eaAViJuX+mA4o18Lfvj8yvA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -22577,7 +22577,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -22621,7 +22621,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -22634,7 +22634,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22645,7 +22645,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -22662,7 +22662,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -22680,7 +22680,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22692,7 +22692,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -22706,7 +22706,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22717,7 +22717,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22728,7 +22728,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22738,7 +22738,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22749,7 +22749,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22761,7 +22761,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22774,7 +22774,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -22818,7 +22818,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -22827,7 +22827,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22838,7 +22838,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22849,7 +22849,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22860,14 +22860,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-guardduty": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-guardduty/-/client-guardduty-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-guardduty/-/client-guardduty-3.496.0.tgz",
       "integrity": "sha512-fpaD9m36LTXiIjFXw8WXaCB5Lkh6NQH1sj+O3/8f4GWzDs1flFaDtJ1+AqYlkfcr1iEHCaJjuIJ8zUMclj9u3Q==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -22915,7 +22915,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -22959,7 +22959,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -22972,7 +22972,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -22983,7 +22983,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -23000,7 +23000,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -23018,7 +23018,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23030,7 +23030,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -23044,7 +23044,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23055,7 +23055,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23066,7 +23066,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23076,7 +23076,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23087,7 +23087,7 @@
         },
         "@aws-sdk/middleware-signing": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
           "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23101,7 +23101,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23113,7 +23113,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23126,7 +23126,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -23170,7 +23170,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -23179,7 +23179,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23190,7 +23190,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23201,7 +23201,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23212,14 +23212,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-iam": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-iam/-/client-iam-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-iam/-/client-iam-3.490.0.tgz",
       "integrity": "sha512-jMGKufnBd26DRcwWvv4MxR+mXgLh7KezpxZrT16lxR88U5sD8gOXohj1I1t5f8W8ihON1Ml8EJU++ui6KAowMw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -23268,7 +23268,7 @@
       "dependencies": {
         "@aws-sdk/client-sts": {
           "version": "3.490.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
           "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -23315,14 +23315,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-kinesis": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-kinesis/-/client-kinesis-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kinesis/-/client-kinesis-3.496.0.tgz",
       "integrity": "sha512-GHFV9XGfFQXjGRlU17XtRkkvR+IUDRB5qaUqDb8hsCEwC4SUtGk4xK1LBI7lf260fZQar8sKxCpi6xhj67QlQQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -23373,7 +23373,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -23417,7 +23417,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -23430,7 +23430,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23441,7 +23441,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -23458,7 +23458,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -23476,7 +23476,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23488,7 +23488,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -23502,7 +23502,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23513,7 +23513,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23524,7 +23524,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23534,7 +23534,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23545,7 +23545,7 @@
         },
         "@aws-sdk/middleware-signing": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
           "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23559,7 +23559,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23571,7 +23571,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23584,7 +23584,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -23628,7 +23628,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -23637,7 +23637,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23648,7 +23648,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23659,7 +23659,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23670,14 +23670,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-kms": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-kms/-/client-kms-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-kms/-/client-kms-3.496.0.tgz",
       "integrity": "sha512-LJKekt6zLxoaDyQN8HPJyuxxMja31w0+yaeafrqQqO5RX75YpWm8gM4aLk51C9uO5p4NGCQTrccdhhjbNXWz/w==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -23724,7 +23724,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -23768,7 +23768,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -23781,7 +23781,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23792,7 +23792,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -23809,7 +23809,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -23827,7 +23827,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23839,7 +23839,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -23853,7 +23853,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23864,7 +23864,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23875,7 +23875,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23885,7 +23885,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23896,7 +23896,7 @@
         },
         "@aws-sdk/middleware-signing": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
           "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23910,7 +23910,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23922,7 +23922,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23935,7 +23935,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -23979,7 +23979,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -23988,7 +23988,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -23999,7 +23999,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24010,7 +24010,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24021,14 +24021,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-lambda": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-lambda/-/client-lambda-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-lambda/-/client-lambda-3.496.0.tgz",
       "integrity": "sha512-HsypBL5BIxK/2MPZ7mKsAypEn98Jws5kWKmOzVACOvboyvpgaDgrFqubNWkHPWlwg8vJBjixhrQpHxp1vzeVUw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -24080,7 +24080,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -24124,7 +24124,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -24137,7 +24137,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24148,7 +24148,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -24165,7 +24165,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -24183,7 +24183,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24195,7 +24195,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -24209,7 +24209,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24220,7 +24220,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24231,7 +24231,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24241,7 +24241,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24252,7 +24252,7 @@
         },
         "@aws-sdk/middleware-signing": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
           "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24266,7 +24266,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24278,7 +24278,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24291,7 +24291,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -24335,7 +24335,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -24344,7 +24344,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24355,7 +24355,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24366,7 +24366,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24377,14 +24377,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-organizations": {
       "version": "3.497.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-organizations/-/client-organizations-3.497.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-organizations/-/client-organizations-3.497.0.tgz",
       "integrity": "sha512-A3vsA7iXr5Uu3+V2pDHJ0JraelNNpa4lRqKJWYL8I5hWU2VTfz5hHK+A9+YVs4xnTfn33w4zUmUBn8IbCc26Lw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -24431,7 +24431,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -24475,7 +24475,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -24488,7 +24488,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24499,7 +24499,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -24516,7 +24516,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -24534,7 +24534,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24546,7 +24546,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -24560,7 +24560,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24571,7 +24571,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24582,7 +24582,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24592,7 +24592,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24603,7 +24603,7 @@
         },
         "@aws-sdk/middleware-signing": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
           "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24617,7 +24617,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24629,7 +24629,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24642,7 +24642,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -24686,7 +24686,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -24695,7 +24695,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24706,7 +24706,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24717,7 +24717,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24728,14 +24728,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-rds": {
       "version": "3.497.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-rds/-/client-rds-3.497.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-rds/-/client-rds-3.497.0.tgz",
       "integrity": "sha512-W0rPMRlcy4cbg68D/XmtZQy5DWBkjsQyhrngPKx+4fNpwghnaTom0CDf6pk/xq1IOvY4aGJ6CM3uAoUs9pkuZQ==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -24785,7 +24785,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -24829,7 +24829,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -24842,7 +24842,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24853,7 +24853,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -24870,7 +24870,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -24888,7 +24888,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24900,7 +24900,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -24914,7 +24914,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24925,7 +24925,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24936,7 +24936,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24946,7 +24946,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24957,7 +24957,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24969,7 +24969,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -24982,7 +24982,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -25026,7 +25026,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -25035,7 +25035,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25046,7 +25046,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25057,7 +25057,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25068,14 +25068,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-redshift": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-redshift/-/client-redshift-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-redshift/-/client-redshift-3.496.0.tgz",
       "integrity": "sha512-pg520g/QHpFbwjK0HnlMmHcbi0N1N35dFxyzQg6OIXQV5v4E0omg49FnB+uLo5AYRaJ2YvdT7Vle9fda4gJ0bg==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -25124,7 +25124,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -25168,7 +25168,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -25181,7 +25181,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25192,7 +25192,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -25209,7 +25209,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -25227,7 +25227,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25239,7 +25239,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -25253,7 +25253,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25264,7 +25264,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25275,7 +25275,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25285,7 +25285,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25296,7 +25296,7 @@
         },
         "@aws-sdk/middleware-signing": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.496.0.tgz",
           "integrity": "sha512-Oq73Brs4IConvWnRlh8jM1V7LHoTw9SVQklu/QW2FPlNrB3B8fuTdWHHYIWv7ybw1bykXoCY99v865Mmq/Or/g==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25310,7 +25310,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25322,7 +25322,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25335,7 +25335,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -25379,7 +25379,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -25388,7 +25388,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25399,7 +25399,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25410,7 +25410,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25421,14 +25421,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-s3": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-s3/-/client-s3-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.490.0.tgz",
       "integrity": "sha512-fBj3CJ3+5R+l/sc93Z9mKw8gM2b9K6vEhC9qSCG2XNymLd9YqlRft1peQ7VymrWywAHX3Koz1GCUrFEVNONiMw==",
       "requires": {
         "@aws-crypto/sha1-browser": "3.0.0",
@@ -25493,7 +25493,7 @@
       "dependencies": {
         "@aws-sdk/client-sts": {
           "version": "3.490.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.490.0.tgz",
           "integrity": "sha512-n2vQ5Qu2qi2I0XMI+IH99ElpIRHOJTa1+sqNC4juMYxKQBMvw+EnsqUtaL3QvTHoyxNB/R7mpkeBB6SzPQ1TtA==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -25540,14 +25540,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-sqs": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sqs/-/client-sqs-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sqs/-/client-sqs-3.496.0.tgz",
       "integrity": "sha512-Fo/Kz9nEbGso/lJ7piPGyvSeGWRwgPrC5vgKh0D8cwVhBY2LmRVHfBtJ1p42q0TUJY6i/1TOFxXZdvavYcwb9Q==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -25596,7 +25596,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -25640,7 +25640,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -25653,7 +25653,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25664,7 +25664,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -25681,7 +25681,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -25699,7 +25699,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25711,7 +25711,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -25725,7 +25725,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25736,7 +25736,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25747,7 +25747,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25757,7 +25757,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25768,7 +25768,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25780,7 +25780,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25793,7 +25793,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -25837,7 +25837,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -25846,7 +25846,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25857,7 +25857,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25868,7 +25868,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -25879,14 +25879,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-sso": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.490.0.tgz",
       "integrity": "sha512-yfxoHmCL1w/IKmFRfzCxdVCQrGlSQf4eei9iVEm5oi3iE8REFyPj3o/BmKQEHG3h2ITK5UbdYDb5TY4xoYHsyA==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -25930,14 +25930,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/client-sts": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sts/-/client-sts-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.496.0.tgz",
       "integrity": "sha512-3pSdqgegdwbK3CT1WvGHhA+Bf91R9cr8G1Ynp+iU2wZvy8ueJfMUk0NYfjo3EEv0YhSbMLKuduzZfvQHFHXYhw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -25984,7 +25984,7 @@
       "dependencies": {
         "@aws-sdk/client-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.496.0.tgz",
           "integrity": "sha512-fuaMuxKg7CMUsP9l3kxYWCOxFsBjdA0xj5nlikaDm1661/gB4KkAiGqRY8LsQkpNXvXU8Nj+f7oCFADFyGYzyw==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -26028,7 +26028,7 @@
         },
         "@aws-sdk/core": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.496.0.tgz",
           "integrity": "sha512-yT+ug7Cw/3eJi7x2es0+46x12+cIJm5Xv+GPWsrTFD1TKgqO/VPEgfDtHFagDNbFmjNQA65Ygc/kEdIX9ICX/A==",
           "requires": {
             "@smithy/core": "^1.3.1",
@@ -26041,7 +26041,7 @@
         },
         "@aws-sdk/credential-provider-env": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.496.0.tgz",
           "integrity": "sha512-lukQMJ8SWWP5RqkRNOHi/H+WMhRvSWa3Fc5Jf/VP6xHiPLfF1XafcvthtV91e0VwPCiseI+HqChrcGq8pvnxHw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26052,7 +26052,7 @@
         },
         "@aws-sdk/credential-provider-ini": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.496.0.tgz",
           "integrity": "sha512-2nD1jp1sIwcQaWK1y/9ruQOkW16RUxZpzgjbW/gnK3iiUXwx+/FNQWxshud+GTSx3Q4x6eIhqsbjtP4VVPPuUA==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -26069,7 +26069,7 @@
         },
         "@aws-sdk/credential-provider-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.496.0.tgz",
           "integrity": "sha512-IVF9RvLePfRa5S5/eBIRChJCWOzQkGwM8P/L79Gl84u/cH2oSG4NtUI/YTDlrtmnYn7YsGhINSV0WnzfF2twfQ==",
           "requires": {
             "@aws-sdk/credential-provider-env": "3.496.0",
@@ -26087,7 +26087,7 @@
         },
         "@aws-sdk/credential-provider-process": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.496.0.tgz",
           "integrity": "sha512-/YZscCTGOKVmGr916Th4XF8Sz6JDtZ/n2loHG9exok9iy/qIbACsTRNLP9zexPxhPoue/oZqecY5xbVljfY34A==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26099,7 +26099,7 @@
         },
         "@aws-sdk/credential-provider-sso": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.496.0.tgz",
           "integrity": "sha512-eP7GxpT2QYubSDG7uk1GJW4eNymZCq65IxDyEFCXOP/kfqkxriCY+iVEFG6/Mo3LxvgrgHXU4jxrCAXMAWN43g==",
           "requires": {
             "@aws-sdk/client-sso": "3.496.0",
@@ -26113,7 +26113,7 @@
         },
         "@aws-sdk/credential-provider-web-identity": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.496.0.tgz",
           "integrity": "sha512-IbP+qLlvJSpNPj+zW6TtFuLRTK5Tf0hW+2pom4vFyi5YSH4pn8UOC136UdewX8vhXGS9BJQ5zBDMasIyl5VeGQ==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26124,7 +26124,7 @@
         },
         "@aws-sdk/middleware-host-header": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.496.0.tgz",
           "integrity": "sha512-jUdPpSJeqCYXf6hSjfwsfHway7peIV8Vz51w/BN91bF4vB/bYwAC5o9/iJiK/EoByp5asxA8fg9wFOyGjzdbLg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26135,7 +26135,7 @@
         },
         "@aws-sdk/middleware-logger": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.496.0.tgz",
           "integrity": "sha512-EwMVSY6iBMeGbVnvwdaFl/ClMS/YWtxCAo+bcEtgk8ltRuo7qgbJem8Km/fvWC1vdWvIbe4ArdJ8iGzq62ffAw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26145,7 +26145,7 @@
         },
         "@aws-sdk/middleware-recursion-detection": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.496.0.tgz",
           "integrity": "sha512-+IuOcFsfqg2WAnaEzH6KhVbicqCxtOq9w3DH2jwTpddRlCx2Kqf6wCzg8luhHRGyjBZdsbIS+OXwyMevoppawA==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26156,7 +26156,7 @@
         },
         "@aws-sdk/middleware-user-agent": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.496.0.tgz",
           "integrity": "sha512-+iMtRxFk0GmFWNUF4ilxylOQd9PZdR4ZC9jkcPIh1PZlvKtpCyFywKlk5RRZKklSoJ/CttcqwhMvOXTNbWm/0w==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26168,7 +26168,7 @@
         },
         "@aws-sdk/region-config-resolver": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.496.0.tgz",
           "integrity": "sha512-URrNVOPHPgEDm6QFu6lDC2cUFs+Jx23mA3jEwCvoKlXiEY/ZoWjH8wlX3OMUlLrF1qoUTuD03jjrJzF6zoCgug==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26181,7 +26181,7 @@
         },
         "@aws-sdk/token-providers": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.496.0.tgz",
           "integrity": "sha512-fyi8RcObEa1jNETJdc2H6q9VHrrdKCj/b6+fbLvymb7mUVRd0aWUn+24SNUImnSOnrwYnwaMfyyEC388X4MbFQ==",
           "requires": {
             "@aws-crypto/sha256-browser": "3.0.0",
@@ -26225,7 +26225,7 @@
         },
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -26234,7 +26234,7 @@
         },
         "@aws-sdk/util-endpoints": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.496.0.tgz",
           "integrity": "sha512-1QzOiWHi383ZwqSi/R2KgKCd7M+6DxkxI5acqLPm8mvDRDP2jRjrnVaC0g9/tlttWousGEemDUWStwrD2mVYSw==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26245,7 +26245,7 @@
         },
         "@aws-sdk/util-user-agent-browser": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.496.0.tgz",
           "integrity": "sha512-4j2spN+h0I0qfSMsGvJXTfQBu1e18rPdekKvzsGJxhaAE1tNgUfUT4nbvc5uVn0sNjZmirskmJ3kfbzVOrqIFg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26256,7 +26256,7 @@
         },
         "@aws-sdk/util-user-agent-node": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.496.0.tgz",
           "integrity": "sha512-h0Ax0jlDc7UIo3KoSI4C4tVLBFoiAdx3+DhTVfgLS7x93d41dMlziPoBX2RgdcFn37qnzw6AQKTVTMwDbRCGpg==",
           "requires": {
             "@aws-sdk/types": "3.496.0",
@@ -26267,14 +26267,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/core": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/core/-/core-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.490.0.tgz",
       "integrity": "sha512-TSBWkXtxMU7q1Zo6w3v5wIOr/sj7P5Jw3OyO7lJrFGsPsDC2xwpxkVqTesDxkzgMRypO52xjYEmveagn1xxBHg==",
       "requires": {
         "@smithy/core": "^1.2.2",
@@ -26287,14 +26287,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/credential-provider-env": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-env/-/credential-provider-env-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.489.0.tgz",
       "integrity": "sha512-5PqYsx9G5SB2tqPT9/z/u0EkF6D4wP6HTMWQs+DfMdmwXihrqQAgeYaTtV3KbXqb88p6sfacwxhUvE6+Rm494w==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26305,14 +26305,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/credential-provider-ini": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.490.0.tgz",
       "integrity": "sha512-7m63zyCpVqj9FsoDxWMWWRvL6c7zZzOcXYkHZmHujVVlmAXH0RT/vkXFkYgt+Ku+ov+v5NQrzwO5TmVoRt6O8g==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.489.0",
@@ -26329,14 +26329,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/credential-provider-node": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-node/-/credential-provider-node-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.490.0.tgz",
       "integrity": "sha512-Gh33u2O5Xbout8G3z/Z5H/CZzdG1ophxf/XS3iMFxA1cazQ7swY1UMmGvB7Lm7upvax5anXouItD1Ph3gzKc4w==",
       "requires": {
         "@aws-sdk/credential-provider-env": "3.489.0",
@@ -26354,14 +26354,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/credential-provider-process": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-process/-/credential-provider-process-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.489.0.tgz",
       "integrity": "sha512-3vKQYJZ5cZYjy0870CPmbmKRBgATw2xCygxhn4m4UDCjOXVXcGUtYD51DMWsvBo3S0W8kH+FIJV4yuEDMFqLFQ==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26373,14 +26373,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/credential-provider-sso": {
       "version": "3.490.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.490.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.490.0.tgz",
       "integrity": "sha512-3UUBUoPbFvT58IhS4Vb23omYj/QPNkjgxu9p9ruQ3KSjLkanI4w8t/l/jljA65q83P7CoLnM5UKG9L7RA8/V1Q==",
       "requires": {
         "@aws-sdk/client-sso": "3.490.0",
@@ -26394,14 +26394,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/credential-provider-web-identity": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.489.0.tgz",
       "integrity": "sha512-mjIuE2Wg1H/ds0nXQ/7vfusEDudmdd8YzKZI1y5O4n60iZZtyB2RNIECtvLMx1EQAKclidY7/06qQkArrGau5Q==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26412,14 +26412,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-bucket-endpoint": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.489.0.tgz",
       "integrity": "sha512-6rJ5bpNMKo7sEKQ6p2DMbQwM+ahMYASRxfdyH7hs18blvlcS20H1RYpNmJMqPPjxMwUWruty2JPMIRl4DFcv8w==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26433,14 +26433,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-expect-continue": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.489.0.tgz",
       "integrity": "sha512-2RZfnVZFaGHwzPDQJsyf9SXufu1gUd4VsMhm7dC7SWF85XmpDrozbFznS/tD22QdtyWjerLoydZJMq229hpPqg==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26451,14 +26451,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-flexible-checksums": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.489.0.tgz",
       "integrity": "sha512-Cy3rBUMr4P7raxzrJFWNRshfKrKV2EojawaC9Bfk/T8aFlV+FmVrRg4ISAXMOfS5pfy3xfAbvkzjOaeqCsGfrA==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
@@ -26473,14 +26473,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-host-header": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-host-header/-/middleware-host-header-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.489.0.tgz",
       "integrity": "sha512-Cl7HJ1jhOfllwf0CRx1eB4ypRGMqdGKWpc0eSTXty7wWSvCdMZUhwfjQqu2bIOIlgYxg/gFu6TVmVZ6g4O8PlA==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26491,14 +26491,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-location-constraint": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.489.0.tgz",
       "integrity": "sha512-NIVr+kHR2N6gxFeE3TNw2mEBxgj0N9xXBLy3dNYMMlAUvQlT/0z9HlC9+3XqcTS/Z5ElF/+pei6nqXTVt0He9A==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26508,14 +26508,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-logger": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-logger/-/middleware-logger-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.489.0.tgz",
       "integrity": "sha512-+EVDnWese61MdImcBNAgz/AhTcIZJaska/xsU3GWU9CP905x4a4qZdB7fExFMDu1Jlz5pJqNteFYYHCFMJhHfg==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26525,14 +26525,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-recursion-detection": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.489.0.tgz",
       "integrity": "sha512-m4rU+fTzziQcu9DKjRNZ4nQlXENEd2ZnJblJV4ONdWqqEjbmOgOj3P6aCCQlJdIbzuNvX1FBOZ5tY59ZpERo7Q==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26543,14 +26543,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-sdk-ec2": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-ec2/-/middleware-sdk-ec2-3.496.0.tgz",
       "integrity": "sha512-fk3ZdXPujb1FTuxIRUudN4yM+/gjjzv155U9pW6yIaAAzEK/CRV0SkbFP6KDkCClqMCmoYjTBzFB5ZY4gQnAhQ==",
       "requires": {
         "@aws-sdk/types": "3.496.0",
@@ -26565,7 +26565,7 @@
       "dependencies": {
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -26574,14 +26574,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-sdk-rds": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-rds/-/middleware-sdk-rds-3.496.0.tgz",
       "integrity": "sha512-eKJzcMTSC5aC3SWY16CwTWkwDbdt1QKrFDAS+sJkoWJ9WOBKR+H0zmRD2WHlSV4xytuaFt03YDKnmKs9LAxBiA==",
       "requires": {
         "@aws-sdk/types": "3.496.0",
@@ -26595,7 +26595,7 @@
       "dependencies": {
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -26604,14 +26604,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-sdk-s3": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.489.0.tgz",
       "integrity": "sha512-/GGASx7mK9qEgy1znvleYMZKVqm3sOdGghqKdy2zgoGcH2jH+fZrLM0lDMT9bvdITmOCbJJs2rVHP3xm/ZWcXg==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26627,14 +26627,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-sdk-sqs": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.496.0.tgz",
       "integrity": "sha512-CkZLaKeplUcir+MFgYi+xVs67H6pgnyNIcS6PZA9fQq14ERVhiKoXAhPLaAbBt7JDScCgtoD1ZsPvSHMRSi18w==",
       "requires": {
         "@aws-sdk/types": "3.496.0",
@@ -26646,7 +26646,7 @@
       "dependencies": {
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -26655,14 +26655,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-signing": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-signing/-/middleware-signing-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.489.0.tgz",
       "integrity": "sha512-rlHcWYZn6Ym3v/u0DvKNDiD7ogIzEsHlerm0lowTiQbszkFobOiUClRTALwvsUZdAAztl706qO1OKbnGnD6Ubw==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26676,14 +26676,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-ssec": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-ssec/-/middleware-ssec-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.489.0.tgz",
       "integrity": "sha512-5RQg8dqERAmi1OfVEV9fbTA5NKmcvKDYP79YtH08IEFIsHWU1Y5NoqL7mXkkNyBrJNBVyasYijAbTzOuM707eg==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26693,14 +26693,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/middleware-user-agent": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.489.0.tgz",
       "integrity": "sha512-M54Cv2fAN3GGgdfUjLtZ4wFUIrfM/ivbXv4DgpcNsacEQ2g4H+weQgKp41X7XZW8MWAzl+k1zJaryK69RYNQkQ==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26712,14 +26712,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/region-config-resolver": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/region-config-resolver/-/region-config-resolver-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.489.0.tgz",
       "integrity": "sha512-UvrnB78XTz9ddby7mr0vuUHn2MO3VTjzaIu+GQhyedMGQU0QlIQrYOlzbbu4LC5rL1O8FxFLUxRe/AAjgwyuGw==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26732,14 +26732,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/signature-v4-multi-region": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.489.0.tgz",
       "integrity": "sha512-kYFM7Opu36EkFlzXdVNOBFpQApgnuaTu/U/qYhGyuzeD+HNnYgZEsd/tDro1DQ074jVy3GN9ttJSYxq5I4oTkA==",
       "requires": {
         "@aws-sdk/middleware-sdk-s3": "3.489.0",
@@ -26752,14 +26752,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/token-providers": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/token-providers/-/token-providers-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.489.0.tgz",
       "integrity": "sha512-hSgjB8CMQoA8EIQ0ripDjDtbBcWDSa+7vSBYPIzksyknaGERR/GUfGXLV2dpm5t17FgFG6irT5f3ZlBzarL8Dw==",
       "requires": {
         "@aws-crypto/sha256-browser": "3.0.0",
@@ -26803,14 +26803,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/types": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.489.0.tgz",
       "integrity": "sha512-kcDtLfKog/p0tC4gAeqJqWxAiEzfe2LRPnKamvSG2Mjbthx4R/alE2dxyIq/wW+nvRv0fqR3OD5kD1+eVfdr/w==",
       "requires": {
         "@smithy/types": "^2.8.0",
@@ -26819,14 +26819,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/util-arn-parser": {
       "version": "3.465.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-arn-parser/-/util-arn-parser-3.465.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.465.0.tgz",
       "integrity": "sha512-zOJ82vzDJFqBX9yZBlNeHHrul/kpx/DCoxzW5UBbZeb26kfV53QhMSoEmY8/lEbBqlqargJ/sgRC845GFhHNQw==",
       "requires": {
         "tslib": "^2.5.0"
@@ -26834,14 +26834,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/util-endpoints": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-endpoints/-/util-endpoints-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.489.0.tgz",
       "integrity": "sha512-uGyG1u84ATX03mf7bT4xD9XD/vlYJGD5+RxMN/UpzeTfzXfh+jvCQWbOQ44z8ttFJWYQQqrLxkfpF/JgvALzLA==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26852,14 +26852,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/util-format-url": {
       "version": "3.496.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-format-url/-/util-format-url-3.496.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.496.0.tgz",
       "integrity": "sha512-GYRqLEUVoIkD8+ULliODFWWRHGyjlanLCnj8faahZXUke6Ey32MG40RgPTu/2eFkUyS6U7sVdt7oLY8MIHShPQ==",
       "requires": {
         "@aws-sdk/types": "3.496.0",
@@ -26870,7 +26870,7 @@
       "dependencies": {
         "@aws-sdk/types": {
           "version": "3.496.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/types/-/types-3.496.0.tgz",
+          "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.496.0.tgz",
           "integrity": "sha512-umkGadK4QuNQaMoDICMm7NKRI/mYSXiyPjcn3d53BhsuArYU/52CebGQKdt4At7SwwsiVJZw9RNBHyN5Mm0HVw==",
           "requires": {
             "@smithy/types": "^2.9.1",
@@ -26879,14 +26879,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/util-locate-window": {
       "version": "3.465.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-locate-window/-/util-locate-window-3.465.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.465.0.tgz",
       "integrity": "sha512-f+QNcWGswredzC1ExNAB/QzODlxwaTdXkNT5cvke2RLX8SFU5pYk6h4uCtWC0vWPELzOfMfloBrJefBzlarhsw==",
       "requires": {
         "tslib": "^2.5.0"
@@ -26894,14 +26894,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/util-retry": {
       "version": "3.374.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-retry/-/util-retry-3.374.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.374.0.tgz",
       "integrity": "sha512-0p/trhYU+Ys8j3vMnWCvAkSOL6JRMooV9dVlQ+o7EHbQs9kDtnyucMUHU09ahHSIPTA/n/013hv7bzIt3MyKQg==",
       "requires": {
         "@smithy/util-retry": "^1.0.3",
@@ -26910,12 +26910,12 @@
       "dependencies": {
         "@smithy/service-error-classification": {
           "version": "1.1.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/service-error-classification/-/service-error-classification-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-1.1.0.tgz",
           "integrity": "sha512-OCTEeJ1igatd5kFrS2VDlYbainNNpf7Lj1siFOxnRWqYOP9oNvC5HOJBd3t+Z8MbrmehBtuDJ2QqeBsfeiNkww=="
         },
         "@smithy/util-retry": {
           "version": "1.1.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-retry/-/util-retry-1.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-1.1.0.tgz",
           "integrity": "sha512-ygQW5HBqYXpR3ua09UciS0sL7UGJzGiktrKkOuEJwARoUuzz40yaEGU6xd9Gs7KBmAaFC8gMfnghHtwZ2nyBCQ==",
           "requires": {
             "@smithy/service-error-classification": "^1.1.0",
@@ -26924,14 +26924,14 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/util-user-agent-browser": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.489.0.tgz",
       "integrity": "sha512-85B9KMsuMpAZauzWQ16r52ZBAHYnznW6BVitnBglsibN7oJKn10Hggt4QGuRhvQFCxQ8YhvBl7r+vQGFO4hxIw==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26942,14 +26942,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/util-user-agent-node": {
       "version": "3.489.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.489.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.489.0.tgz",
       "integrity": "sha512-CYdkBHig8sFNc0dv11Ni9WXvZQHeI5+z77OrDHKkbidFx/V4BDTuwZw4K1vWg62pzFOEfzunJFiULRcDZWJR3w==",
       "requires": {
         "@aws-sdk/types": "3.489.0",
@@ -26960,14 +26960,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/util-utf8-browser": {
       "version": "3.259.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
       "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
       "requires": {
         "tslib": "^2.3.1"
@@ -26975,14 +26975,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@aws-sdk/xml-builder": {
       "version": "3.485.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@aws-sdk/xml-builder/-/xml-builder-3.485.0.tgz",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.485.0.tgz",
       "integrity": "sha512-xQexPM6LINOIkf3NLFywplcbApifZRMWFN41TDWYSNgCUa5uC9fntfenw8N/HTx1n+McRCWSAFBTjDqY/2OLCQ==",
       "requires": {
         "@smithy/types": "^2.8.0",
@@ -26991,14 +26991,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@babel/code-frame": {
       "version": "7.23.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
       "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dev": true,
       "requires": {
@@ -27076,13 +27076,13 @@
     },
     "@babel/helper-environment-visitor": {
       "version": "7.22.20",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.22.20.tgz",
       "integrity": "sha512-zfedSIzFhat/gFhWfHtgWvlec0nqB9YEIVrpuwjruLlXfUSnA8cJB0miHKwqDnQ7d32aKo2xt88/xZptwxbfhA==",
       "dev": true
     },
     "@babel/helper-function-name": {
       "version": "7.23.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
       "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dev": true,
       "requires": {
@@ -27092,7 +27092,7 @@
     },
     "@babel/helper-module-imports": {
       "version": "7.22.15",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.22.15.tgz",
       "integrity": "sha512-0pYVBnDKZO2fnSPCrgM/6WMc7eS20Fbok+0r88fp+YtWVLZrp4CkafFGIp+W0VKw4a22sgebPT99y+FDNMdP4w==",
       "dev": true,
       "requires": {
@@ -27101,7 +27101,7 @@
     },
     "@babel/helper-module-transforms": {
       "version": "7.23.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.23.3.tgz",
       "integrity": "sha512-7bBs4ED9OmswdfDzpz4MpWgSrV7FXlc3zIagvLFjS5H+Mk7Snr21vQ6QwrsoCGMfNC4e4LQPdoULEt4ykz0SRQ==",
       "dev": true,
       "requires": {
@@ -27114,13 +27114,13 @@
     },
     "@babel/helper-plugin-utils": {
       "version": "7.22.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.22.5.tgz",
       "integrity": "sha512-uLls06UVKgFG9QD4OeFYLEGteMIAa5kpTPcFL28yuCIIzsf6ZyKZMllKVOCZFhiZ5ptnwX4mtKdWCBE/uT4amg==",
       "dev": true
     },
     "@babel/helper-simple-access": {
       "version": "7.22.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.22.5.tgz",
       "integrity": "sha512-n0H99E/K+Bika3++WNL17POvo4rKWZ7lZEp1Q+fStVbUi8nxPQEBOlTmCOxW/0JsS56SKKQ+ojAe2pHKJHN35w==",
       "dev": true,
       "requires": {
@@ -27129,7 +27129,7 @@
     },
     "@babel/helper-split-export-declaration": {
       "version": "7.22.6",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.22.6.tgz",
       "integrity": "sha512-AsUnxuLhRYsisFiaJwvp1QF+I3KjD5FOxut14q/GzovUe6orHLesW2C7d754kRm53h5gqrz6sFl6sxc4BVtE/g==",
       "dev": true,
       "requires": {
@@ -27138,19 +27138,19 @@
     },
     "@babel/helper-string-parser": {
       "version": "7.23.4",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
       "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "dev": true
     },
     "@babel/helper-validator-identifier": {
       "version": "7.22.20",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.22.20.tgz",
       "integrity": "sha512-Y4OZ+ytlatR8AI+8KZfKuL5urKp7qey08ha31L8b3BwewJAoJamTzyvxPR/5D+KkdJCGPq/+8TukHBlY10FX9A==",
       "dev": true
     },
     "@babel/helper-validator-option": {
       "version": "7.23.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.23.5.tgz",
       "integrity": "sha512-85ttAOMLsr53VgXkTbkx8oA6YTfT4q7/HzXSLEYmjcSTJPMPQtvq1BD79Byep5xMUYbGRzEpDsjUf3dyp54IKw==",
       "dev": true
     },
@@ -27167,7 +27167,7 @@
     },
     "@babel/highlight": {
       "version": "7.23.4",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/highlight/-/highlight-7.23.4.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
       "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dev": true,
       "requires": {
@@ -27178,7 +27178,7 @@
     },
     "@babel/parser": {
       "version": "7.23.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/parser/-/parser-7.23.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
       "integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
       "dev": true
     },
@@ -27292,7 +27292,7 @@
     },
     "@babel/template": {
       "version": "7.22.15",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/template/-/template-7.22.15.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.22.15.tgz",
       "integrity": "sha512-QPErUVm4uyJa60rkI73qneDacvdvzxshT3kksGqlGWYdOTIUOwJ7RDUL8sGqslY1uXWSL6xMFKEXDS3ox2uF0w==",
       "dev": true,
       "requires": {
@@ -27327,7 +27327,7 @@
     },
     "@babel/types": {
       "version": "7.23.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@babel/types/-/types-7.23.5.tgz",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
       "integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
       "dev": true,
       "requires": {
@@ -27664,7 +27664,7 @@
     },
     "@jest/expect-utils": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/expect-utils/-/expect-utils-28.1.3.tgz",
       "integrity": "sha512-wvbi9LUrHJLn3NlDW6wF2hvIMtd4JUl2QNVrjq+IBSHirgfrR3o9RnVtxzdEGO2n9JyIWwHnLfby5KzqBGg2YA==",
       "dev": true,
       "requires": {
@@ -27673,7 +27673,7 @@
       "dependencies": {
         "jest-get-type": {
           "version": "28.0.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
           "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
           "dev": true
         }
@@ -27790,7 +27790,7 @@
     },
     "@jest/schemas": {
       "version": "28.1.3",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@jest/schemas/-/schemas-28.1.3.tgz",
+      "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-28.1.3.tgz",
       "integrity": "sha512-/l/VWsdt/aBXgjshLWOFyFt3IVdYypu5y2Wn2rOO1un6nkqIn8SLXzgIMYXFyYsRWDyF5EthmKJMIdJvk08grg==",
       "dev": true,
       "requires": {
@@ -28331,7 +28331,7 @@
     },
     "@sinclair/typebox": {
       "version": "0.24.51",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinclair/typebox/-/typebox-0.24.51.tgz",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.24.51.tgz",
       "integrity": "sha512-1P1OROm/rdubP5aFDSZQILU0vrLCJ4fvHt6EoqHEM+2D/G5MK3bIaymUKLit8Js9gbns5UyJnkP/TZROLw4tUA==",
       "dev": true
     },
@@ -28361,13 +28361,13 @@
     },
     "@sinonjs/text-encoding": {
       "version": "0.7.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
       "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
       "dev": true
     },
     "@smithy/abort-controller": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-2.1.1.tgz",
       "integrity": "sha512-1+qdrUqLhaALYL0iOcN43EP6yAXXQ2wWZ6taf4S2pNGowmOc5gx+iMQv+E42JizNJjB0+gEadOXeV1Bf7JWL1Q==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28376,14 +28376,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/chunked-blob-reader": {
       "version": "2.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-2.1.0.tgz",
       "integrity": "sha512-meKoKCIXxixSGzUGVXGc1lnn6cEM21XzknDfUmHopPCaYSgt86w3gaJSua8Gr3VYcSkkMTW2MyAygTXprLEOZQ==",
       "requires": {
         "tslib": "^2.5.0"
@@ -28391,14 +28391,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/chunked-blob-reader-native": {
       "version": "2.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-2.1.0.tgz",
       "integrity": "sha512-r9fRVRvQXpuWZtHX3VNAP4PQoCXvRDqcwr15TbaKSdtEJ/f0IPHDQ+M2MOEsYt2234FkNqCzAqtmeJrjpNak2g==",
       "requires": {
         "@smithy/util-base64": "^2.1.0",
@@ -28407,14 +28407,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/config-resolver": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-2.1.1.tgz",
       "integrity": "sha512-lxfLDpZm+AWAHPFZps5JfDoO9Ux1764fOgvRUBpHIO8HWHcSN1dkgsago1qLRVgm1BZ8RCm8cgv99QvtaOWIhw==",
       "requires": {
         "@smithy/node-config-provider": "^2.2.1",
@@ -28426,14 +28426,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/core": {
       "version": "1.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/core/-/core-1.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-1.3.1.tgz",
       "integrity": "sha512-tf+NIu9FkOh312b6M9G4D68is4Xr7qptzaZGZUREELF8ysE1yLKphqt7nsomjKZVwW7WE5pDDex9idowNGRQ/Q==",
       "requires": {
         "@smithy/middleware-endpoint": "^2.4.1",
@@ -28448,14 +28448,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/credential-provider-imds": {
       "version": "2.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-2.2.1.tgz",
       "integrity": "sha512-7XHjZUxmZYnONheVQL7j5zvZXga+EWNgwEAP6OPZTi7l8J4JTeNh9aIOfE5fKHZ/ee2IeNOh54ZrSna+Vc6TFA==",
       "requires": {
         "@smithy/node-config-provider": "^2.2.1",
@@ -28467,14 +28467,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/eventstream-codec": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
       "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
       "requires": {
         "@aws-crypto/crc32": "3.0.0",
@@ -28485,14 +28485,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/eventstream-serde-browser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-2.1.1.tgz",
       "integrity": "sha512-JvEdCmGlZUay5VtlT8/kdR6FlvqTDUiJecMjXsBb0+k1H/qc9ME5n2XKPo8q/MZwEIA1GmGgYMokKGjVvMiDow==",
       "requires": {
         "@smithy/eventstream-serde-universal": "^2.1.1",
@@ -28502,14 +28502,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/eventstream-serde-config-resolver": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-2.1.1.tgz",
       "integrity": "sha512-EqNqXYp3+dk//NmW3NAgQr9bEQ7fsu/CcxQmTiq07JlaIcne/CBWpMZETyXm9w5LXkhduBsdXdlMscfDUDn2fA==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28518,14 +28518,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/eventstream-serde-node": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-2.1.1.tgz",
       "integrity": "sha512-LF882q/aFidFNDX7uROAGxq3H0B7rjyPkV6QDn6/KDQ+CG7AFkRccjxRf1xqajq/Pe4bMGGr+VKAaoF6lELIQw==",
       "requires": {
         "@smithy/eventstream-serde-universal": "^2.1.1",
@@ -28535,14 +28535,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/eventstream-serde-universal": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-2.1.1.tgz",
       "integrity": "sha512-LR0mMT+XIYTxk4k2fIxEA1BPtW3685QlqufUEUAX1AJcfFfxNDKEvuCRZbO8ntJb10DrIFVJR9vb0MhDCi0sAQ==",
       "requires": {
         "@smithy/eventstream-codec": "^2.1.1",
@@ -28552,14 +28552,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/fetch-http-handler": {
       "version": "2.4.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-2.4.1.tgz",
       "integrity": "sha512-VYGLinPsFqH68lxfRhjQaSkjXM7JysUOJDTNjHBuN/ykyRb2f1gyavN9+VhhPTWCy32L4yZ2fdhpCs/nStEicg==",
       "requires": {
         "@smithy/protocol-http": "^3.1.1",
@@ -28571,14 +28571,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/hash-blob-browser": {
       "version": "2.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/hash-blob-browser/-/hash-blob-browser-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-2.1.0.tgz",
       "integrity": "sha512-MVlH6algsOuEaK745oSoymk7Tusny7AqP2bQ1yPzxJiWpHirHnzEzYP/aqZaZ4gWdSLMFF65WOwL6q2ijuKVgA==",
       "requires": {
         "@smithy/chunked-blob-reader": "^2.1.0",
@@ -28589,14 +28589,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/hash-node": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/hash-node/-/hash-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-2.1.1.tgz",
       "integrity": "sha512-Qhoq0N8f2OtCnvUpCf+g1vSyhYQrZjhSwvJ9qvR8BUGOtTXiyv2x1OD2e6jVGmlpC4E4ax1USHoyGfV9JFsACg==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28607,14 +28607,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/hash-stream-node": {
       "version": "2.1.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/hash-stream-node/-/hash-stream-node-2.1.0.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-2.1.0.tgz",
       "integrity": "sha512-qhgWuXt8sVcDKrFNBRQmcIo6wfzONdeKlKDLsau4kKZ7xlEHScgUFtsAHvspV8sVREJIeMbOq4oSFSVmzvOikQ==",
       "requires": {
         "@smithy/types": "^2.9.0",
@@ -28624,14 +28624,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/invalid-dependency": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-2.1.1.tgz",
       "integrity": "sha512-7WTgnKw+VPg8fxu2v9AlNOQ5yaz6RA54zOVB4f6vQuR0xFKd+RzlCpt0WidYTsye7F+FYDIaS/RnJW4pxjNInw==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28640,14 +28640,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/is-array-buffer": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
       "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
       "requires": {
         "tslib": "^2.5.0"
@@ -28655,14 +28655,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/md5-js": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/md5-js/-/md5-js-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-2.1.1.tgz",
       "integrity": "sha512-L3MbIYBIdLlT+MWTYrdVSv/dow1+6iZ1Ad7xS0OHxTTs17d753ZcpOV4Ro7M7tRAVWML/sg2IAp/zzCb6aAttg==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28672,14 +28672,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/middleware-content-length": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-2.1.1.tgz",
       "integrity": "sha512-rSr9ezUl9qMgiJR0UVtVOGEZElMdGFyl8FzWEF5iEKTlcWxGr2wTqGfDwtH3LAB7h+FPkxqv4ZU4cpuCN9Kf/g==",
       "requires": {
         "@smithy/protocol-http": "^3.1.1",
@@ -28689,14 +28689,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/middleware-endpoint": {
       "version": "2.4.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-2.4.1.tgz",
       "integrity": "sha512-XPZTb1E2Oav60Ven3n2PFx+rX9EDsU/jSTA8VDamt7FXks67ekjPY/XrmmPDQaFJOTUHJNKjd8+kZxVO5Ael4Q==",
       "requires": {
         "@smithy/middleware-serde": "^2.1.1",
@@ -28710,14 +28710,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/middleware-retry": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-2.1.1.tgz",
       "integrity": "sha512-eMIHOBTXro6JZ+WWzZWd/8fS8ht5nS5KDQjzhNMHNRcG5FkNTqcKpYhw7TETMYzbLfhO5FYghHy1vqDWM4FLDA==",
       "requires": {
         "@smithy/node-config-provider": "^2.2.1",
@@ -28733,14 +28733,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/middleware-serde": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-2.1.1.tgz",
       "integrity": "sha512-D8Gq0aQBeE1pxf3cjWVkRr2W54t+cdM2zx78tNrVhqrDykRA7asq8yVJij1u5NDtKzKqzBSPYh7iW0svUKg76g==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28749,14 +28749,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/middleware-stack": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-2.1.1.tgz",
       "integrity": "sha512-KPJhRlhsl8CjgGXK/DoDcrFGfAqoqvuwlbxy+uOO4g2Azn1dhH+GVfC3RAp+6PoL5PWPb+vt6Z23FP+Mr6qeCw==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28765,14 +28765,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/node-config-provider": {
       "version": "2.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-2.2.1.tgz",
       "integrity": "sha512-epzK3x1xNxA9oJgHQ5nz+2j6DsJKdHfieb+YgJ7ATWxzNcB7Hc+Uya2TUck5MicOPhDV8HZImND7ZOecVr+OWg==",
       "requires": {
         "@smithy/property-provider": "^2.1.1",
@@ -28783,14 +28783,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/node-http-handler": {
       "version": "2.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-2.3.1.tgz",
       "integrity": "sha512-gLA8qK2nL9J0Rk/WEZSvgin4AppvuCYRYg61dcUo/uKxvMZsMInL5I5ZdJTogOvdfVug3N2dgI5ffcUfS4S9PA==",
       "requires": {
         "@smithy/abort-controller": "^2.1.1",
@@ -28802,14 +28802,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/property-provider": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/property-provider/-/property-provider-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-2.1.1.tgz",
       "integrity": "sha512-FX7JhhD/o5HwSwg6GLK9zxrMUrGnb3PzNBrcthqHKBc3dH0UfgEAU24xnJ8F0uow5mj17UeBEOI6o3CF2k7Mhw==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28818,14 +28818,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/protocol-http": {
       "version": "3.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-3.1.1.tgz",
       "integrity": "sha512-6ZRTSsaXuSL9++qEwH851hJjUA0OgXdQFCs+VDw4tGH256jQ3TjYY/i34N4vd24RV3nrjNsgd1yhb57uMoKbzQ==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28834,14 +28834,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/querystring-builder": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-2.1.1.tgz",
       "integrity": "sha512-C/ko/CeEa8jdYE4gt6nHO5XDrlSJ3vdCG0ZAc6nD5ZIE7LBp0jCx4qoqp7eoutBu7VrGMXERSRoPqwi1WjCPbg==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28851,14 +28851,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/querystring-parser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-2.1.1.tgz",
       "integrity": "sha512-H4+6jKGVhG1W4CIxfBaSsbm98lOO88tpDWmZLgkJpt8Zkk/+uG0FmmqMuCAc3HNM2ZDV+JbErxr0l5BcuIf/XQ==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28867,14 +28867,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/service-error-classification": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-2.1.1.tgz",
       "integrity": "sha512-txEdZxPUgM1PwGvDvHzqhXisrc5LlRWYCf2yyHfvITWioAKat7srQvpjMAvgzf0t6t7j8yHrryXU9xt7RZqFpw==",
       "requires": {
         "@smithy/types": "^2.9.1"
@@ -28882,7 +28882,7 @@
     },
     "@smithy/shared-ini-file-loader": {
       "version": "2.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-2.3.1.tgz",
       "integrity": "sha512-2E2kh24igmIznHLB6H05Na4OgIEilRu0oQpYXo3LCNRrawHAcfDKq9004zJs+sAMt2X5AbY87CUCJ7IpqpSgdw==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -28891,14 +28891,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/signature-v4": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
       "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
       "requires": {
         "@smithy/eventstream-codec": "^2.1.1",
@@ -28913,14 +28913,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/smithy-client": {
       "version": "2.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-2.3.1.tgz",
       "integrity": "sha512-YsTdU8xVD64r2pLEwmltrNvZV6XIAC50LN6ivDopdt+YiF/jGH6PY9zUOu0CXD/d8GMB8gbhnpPsdrjAXHS9QA==",
       "requires": {
         "@smithy/middleware-endpoint": "^2.4.1",
@@ -28933,14 +28933,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/types": {
       "version": "2.9.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/types/-/types-2.9.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
       "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
       "requires": {
         "tslib": "^2.5.0"
@@ -28948,14 +28948,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/url-parser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/url-parser/-/url-parser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-2.1.1.tgz",
       "integrity": "sha512-qC9Bv8f/vvFIEkHsiNrUKYNl8uKQnn4BdhXl7VzQRP774AwIjiSMMwkbT+L7Fk8W8rzYVifzJNYxv1HwvfBo3Q==",
       "requires": {
         "@smithy/querystring-parser": "^2.1.1",
@@ -28965,14 +28965,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-base64": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-base64/-/util-base64-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-2.1.1.tgz",
       "integrity": "sha512-UfHVpY7qfF/MrgndI5PexSKVTxSZIdz9InghTFa49QOvuu9I52zLPLUHXvHpNuMb1iD2vmc6R+zbv/bdMipR/g==",
       "requires": {
         "@smithy/util-buffer-from": "^2.1.1",
@@ -28981,14 +28981,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-body-length-browser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-2.1.1.tgz",
       "integrity": "sha512-ekOGBLvs1VS2d1zM2ER4JEeBWAvIOUKeaFch29UjjJsxmZ/f0L3K3x0dEETgh3Q9bkZNHgT+rkdl/J/VUqSRag==",
       "requires": {
         "tslib": "^2.5.0"
@@ -28996,14 +28996,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-body-length-node": {
       "version": "2.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-2.2.1.tgz",
       "integrity": "sha512-/ggJG+ta3IDtpNVq4ktmEUtOkH1LW64RHB5B0hcr5ZaWBmo96UX2cIOVbjCqqDickTXqBWZ4ZO0APuaPrD7Abg==",
       "requires": {
         "tslib": "^2.5.0"
@@ -29011,14 +29011,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-buffer-from": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
       "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
       "requires": {
         "@smithy/is-array-buffer": "^2.1.1",
@@ -29027,14 +29027,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-config-provider": {
       "version": "2.2.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-2.2.1.tgz",
       "integrity": "sha512-50VL/tx9oYYcjJn/qKqNy7sCtpD0+s8XEBamIFo4mFFTclKMNp+rsnymD796uybjiIquB7VCB/DeafduL0y2kw==",
       "requires": {
         "tslib": "^2.5.0"
@@ -29042,14 +29042,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-defaults-mode-browser": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-2.1.1.tgz",
       "integrity": "sha512-lqLz/9aWRO6mosnXkArtRuQqqZBhNpgI65YDpww4rVQBuUT7qzKbDLG5AmnQTCiU4rOquaZO/Kt0J7q9Uic7MA==",
       "requires": {
         "@smithy/property-provider": "^2.1.1",
@@ -29061,14 +29061,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-defaults-mode-node": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-2.1.1.tgz",
       "integrity": "sha512-tYVrc+w+jSBfBd267KDnvSGOh4NMz+wVH7v4CClDbkdPfnjvImBZsOURncT5jsFwR9KCuDyPoSZq4Pa6+eCUrA==",
       "requires": {
         "@smithy/config-resolver": "^2.1.1",
@@ -29082,14 +29082,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-endpoints": {
       "version": "1.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-1.1.1.tgz",
       "integrity": "sha512-sI4d9rjoaekSGEtq3xSb2nMjHMx8QXcz2cexnVyRWsy4yQ9z3kbDpX+7fN0jnbdOp0b3KSTZJZ2Yb92JWSanLw==",
       "requires": {
         "@smithy/node-config-provider": "^2.2.1",
@@ -29099,14 +29099,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-hex-encoding": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
       "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
       "requires": {
         "tslib": "^2.5.0"
@@ -29114,14 +29114,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-middleware": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
       "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
       "requires": {
         "@smithy/types": "^2.9.1",
@@ -29130,14 +29130,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-retry": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-retry/-/util-retry-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-2.1.1.tgz",
       "integrity": "sha512-Mg+xxWPTeSPrthpC5WAamJ6PW4Kbo01Fm7lWM1jmGRvmrRdsd3192Gz2fBXAMURyXpaNxyZf6Hr/nQ4q70oVEA==",
       "requires": {
         "@smithy/service-error-classification": "^2.1.1",
@@ -29147,14 +29147,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-stream": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-stream/-/util-stream-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-2.1.1.tgz",
       "integrity": "sha512-J7SMIpUYvU4DQN55KmBtvaMc7NM3CZ2iWICdcgaovtLzseVhAqFRYqloT3mh0esrFw+3VEK6nQFteFsTqZSECQ==",
       "requires": {
         "@smithy/fetch-http-handler": "^2.4.1",
@@ -29169,14 +29169,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-uri-escape": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
       "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
       "requires": {
         "tslib": "^2.5.0"
@@ -29184,14 +29184,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-utf8": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
       "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
       "requires": {
         "@smithy/util-buffer-from": "^2.1.1",
@@ -29200,14 +29200,14 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
     },
     "@smithy/util-waiter": {
       "version": "2.1.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-2.1.1.tgz",
       "integrity": "sha512-kYy6BLJJNif+uqNENtJqWdXcpqo1LS+nj1AfXcDhOpqpSHJSAkVySLyZV9fkmuVO21lzGoxjvd1imGGJHph/IA==",
       "requires": {
         "@smithy/abort-controller": "^2.1.1",
@@ -29217,7 +29217,7 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
         }
       }
@@ -29337,7 +29337,7 @@
     },
     "@types/jest": {
       "version": "28.1.8",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@types/jest/-/jest-28.1.8.tgz",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-28.1.8.tgz",
       "integrity": "sha512-8TJkV++s7B6XqnDrzR1m/TT0A0h948Pnl/097veySPN67VRAgQ4gZ7n2KfJo2rVq6njQjdxU3GCCyDvAeuHoiw==",
       "dev": true,
       "requires": {
@@ -29347,7 +29347,7 @@
       "dependencies": {
         "@jest/types": {
           "version": "28.1.3",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@jest/types/-/types-28.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/@jest/types/-/types-28.1.3.tgz",
           "integrity": "sha512-RyjiyMUZrKz/c+zlMFO1pm70DcIlST8AeWTkoUdZevew44wcNZQHsEVOiCVtgVnlFFD82FPaXycys58cf2muVQ==",
           "dev": true,
           "requires": {
@@ -29361,7 +29361,7 @@
         },
         "@types/yargs": {
           "version": "17.0.32",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@types/yargs/-/yargs-17.0.32.tgz",
+          "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.32.tgz",
           "integrity": "sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==",
           "dev": true,
           "requires": {
@@ -29370,13 +29370,13 @@
         },
         "ansi-regex": {
           "version": "5.0.1",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/ansi-regex/-/ansi-regex-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
           "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
           "dev": true
         },
         "ansi-styles": {
           "version": "4.3.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
           "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
@@ -29385,7 +29385,7 @@
         },
         "braces": {
           "version": "3.0.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/braces/-/braces-3.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
           "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
           "dev": true,
           "requires": {
@@ -29394,7 +29394,7 @@
         },
         "chalk": {
           "version": "4.1.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/chalk/-/chalk-4.1.2.tgz",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
           "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
           "dev": true,
           "requires": {
@@ -29404,13 +29404,13 @@
         },
         "ci-info": {
           "version": "3.9.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/ci-info/-/ci-info-3.9.0.tgz",
+          "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-3.9.0.tgz",
           "integrity": "sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==",
           "dev": true
         },
         "color-convert": {
           "version": "2.0.1",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/color-convert/-/color-convert-2.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
           "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
           "dev": true,
           "requires": {
@@ -29419,19 +29419,19 @@
         },
         "color-name": {
           "version": "1.1.4",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/color-name/-/color-name-1.1.4.tgz",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
           "dev": true
         },
         "diff-sequences": {
           "version": "28.1.1",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/diff-sequences/-/diff-sequences-28.1.1.tgz",
+          "resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-28.1.1.tgz",
           "integrity": "sha512-FU0iFaH/E23a+a718l8Qa/19bF9p06kgE0KipMOMadwa3SjnaElKzPaUC0vnibs6/B/9ni97s61mcejk8W1fQw==",
           "dev": true
         },
         "expect": {
           "version": "28.1.3",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/expect/-/expect-28.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/expect/-/expect-28.1.3.tgz",
           "integrity": "sha512-eEh0xn8HlsuOBxFgIss+2mX85VAS4Qy3OSkjV7rlBWljtA4oWH37glVGyOZSZvErDT/yBywZdPGwCXuTvSG85g==",
           "dev": true,
           "requires": {
@@ -29444,7 +29444,7 @@
         },
         "fill-range": {
           "version": "7.0.1",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/fill-range/-/fill-range-7.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
           "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
           "dev": true,
           "requires": {
@@ -29453,19 +29453,19 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "is-number": {
           "version": "7.0.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/is-number/-/is-number-7.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
         },
         "jest-diff": {
           "version": "28.1.3",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-diff/-/jest-diff-28.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/jest-diff/-/jest-diff-28.1.3.tgz",
           "integrity": "sha512-8RqP1B/OXzjjTWkqMX67iqgwBVJRgCyKD3L9nq+6ZqJMdvjE8RgHktqZ6jNrkdMT+dJuYNI3rhQpxaz7drJHfw==",
           "dev": true,
           "requires": {
@@ -29477,13 +29477,13 @@
         },
         "jest-get-type": {
           "version": "28.0.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-get-type/-/jest-get-type-28.0.2.tgz",
+          "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-28.0.2.tgz",
           "integrity": "sha512-ioj2w9/DxSYHfOm5lJKCdcAmPJzQXmbM/Url3rhlghrPvT3tt+7a/+oXc9azkKmLvoiXjtV83bEWqi+vs5nlPA==",
           "dev": true
         },
         "jest-matcher-utils": {
           "version": "28.1.3",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/jest-matcher-utils/-/jest-matcher-utils-28.1.3.tgz",
           "integrity": "sha512-kQeJ7qHemKfbzKoGjHHrRKH6atgxMk8Enkk2iPQ3XwO6oE/KYD8lMYOziCkeSB9G4adPM4nR1DE8Tf5JeWH6Bw==",
           "dev": true,
           "requires": {
@@ -29495,7 +29495,7 @@
         },
         "jest-message-util": {
           "version": "28.1.3",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-message-util/-/jest-message-util-28.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/jest-message-util/-/jest-message-util-28.1.3.tgz",
           "integrity": "sha512-PFdn9Iewbt575zKPf1286Ht9EPoJmYT7P0kY+RibeYZ2XtOr53pDLEFoTWXbd1h4JiGiWpTBC84fc8xMXQMb7g==",
           "dev": true,
           "requires": {
@@ -29512,7 +29512,7 @@
         },
         "jest-util": {
           "version": "28.1.3",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/jest-util/-/jest-util-28.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/jest-util/-/jest-util-28.1.3.tgz",
           "integrity": "sha512-XdqfpHwpcSRko/C35uLYFM2emRAltIIKZiJ9eAmhjsj0CqZMa0p1ib0R5fWIqGhn1a103DebTbpqIaP1qCQ6tQ==",
           "dev": true,
           "requires": {
@@ -29526,7 +29526,7 @@
         },
         "micromatch": {
           "version": "4.0.5",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/micromatch/-/micromatch-4.0.5.tgz",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
           "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
           "dev": true,
           "requires": {
@@ -29536,7 +29536,7 @@
         },
         "pretty-format": {
           "version": "28.1.3",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/pretty-format/-/pretty-format-28.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-28.1.3.tgz",
           "integrity": "sha512-8gFb/To0OmxHR9+ZTb14Df2vNxdGCX8g1xWGUTqUw5TiZvcQf5sHKObd5UcPyLLyowNwDAMTF3XWOG1B6mxl1Q==",
           "dev": true,
           "requires": {
@@ -29548,7 +29548,7 @@
           "dependencies": {
             "ansi-styles": {
               "version": "5.2.0",
-              "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/ansi-styles/-/ansi-styles-5.2.0.tgz",
+              "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
               "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
               "dev": true
             }
@@ -29556,13 +29556,13 @@
         },
         "react-is": {
           "version": "18.2.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/react-is/-/react-is-18.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
           "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
           "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -29571,7 +29571,7 @@
         },
         "to-regex-range": {
           "version": "5.0.1",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
           "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
           "dev": true,
           "requires": {
@@ -29642,7 +29642,7 @@
     },
     "@types/sinon": {
       "version": "10.0.20",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@types/sinon/-/sinon-10.0.20.tgz",
+      "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-10.0.20.tgz",
       "integrity": "sha512-2APKKruFNCAZgx3daAyACGzWuJ028VVCUDk6o2rw/Z4PXT0ogwdV4KUegW0MwVs0Zu59auPXbbuBJHF12Sx1Eg==",
       "dev": true,
       "requires": {
@@ -29651,7 +29651,7 @@
     },
     "@types/sinonjs__fake-timers": {
       "version": "8.1.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
+      "resolved": "https://registry.npmjs.org/@types/sinonjs__fake-timers/-/sinonjs__fake-timers-8.1.5.tgz",
       "integrity": "sha512-mQkU2jY8jJEF7YHjHvsQO8+3ughTL1mcnn96igfhONmR+fUPSKIkefQYpSe8bsly2Ep7oQbn/6VG5/9/0qcArQ==",
       "dev": true
     },
@@ -30091,7 +30091,7 @@
     },
     "aws-sdk-client-mock": {
       "version": "3.0.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock/-/aws-sdk-client-mock-3.0.1.tgz",
       "integrity": "sha512-9VAzJLl8mz99KP9HjOm/93d8vznRRUTpJooPBOunRdUAnVYopCe9xmMuu7eVemu8fQ+w6rP7o5bBK1kAFkB2KQ==",
       "dev": true,
       "requires": {
@@ -30102,7 +30102,7 @@
       "dependencies": {
         "@sinonjs/commons": {
           "version": "3.0.1",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/commons/-/commons-3.0.1.tgz",
+          "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
           "integrity": "sha512-K3mCHKQ9sVh8o1C9cxkwxaOmXoAMlDxC1mYyHrjqOWEcBjYr76t96zL2zlj5dUGZ3HSw240X1qgH3Mjf1yJWpQ==",
           "dev": true,
           "requires": {
@@ -30111,7 +30111,7 @@
         },
         "@sinonjs/fake-timers": {
           "version": "10.3.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
+          "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-10.3.0.tgz",
           "integrity": "sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==",
           "dev": true,
           "requires": {
@@ -30120,7 +30120,7 @@
         },
         "@sinonjs/samsam": {
           "version": "8.0.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/samsam/-/samsam-8.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-8.0.0.tgz",
           "integrity": "sha512-Bp8KUVlLp8ibJZrnvq2foVhP0IVX2CIprMJPK0vqGqgrDa0OHVKeZyBykqskkrdxV6yKBPmGasO8LVjAKR3Gew==",
           "dev": true,
           "requires": {
@@ -30131,7 +30131,7 @@
           "dependencies": {
             "@sinonjs/commons": {
               "version": "2.0.0",
-              "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/commons/-/commons-2.0.0.tgz",
+              "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-2.0.0.tgz",
               "integrity": "sha512-uLa0j859mMrg2slwQYdO/AkrOfmH+X6LTVmNTS9CqexuE2IvVORIkSpJLqePAbEnKJ77aMmCwr1NUZ57120Xcg==",
               "dev": true,
               "requires": {
@@ -30142,25 +30142,25 @@
         },
         "diff": {
           "version": "5.1.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/diff/-/diff-5.1.0.tgz",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
           "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
           "dev": true
         },
         "has-flag": {
           "version": "4.0.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/has-flag/-/has-flag-4.0.0.tgz",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
         "just-extend": {
           "version": "6.2.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/just-extend/-/just-extend-6.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-6.2.0.tgz",
           "integrity": "sha512-cYofQu2Xpom82S6qD778jBDpwvvy39s1l/hrYij2u9AMdQcGRpaBu6kY4mVhuno5kJVi1DAz4aiphA2WI1/OAw==",
           "dev": true
         },
         "nise": {
           "version": "5.1.7",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/nise/-/nise-5.1.7.tgz",
+          "resolved": "https://registry.npmjs.org/nise/-/nise-5.1.7.tgz",
           "integrity": "sha512-wWtNUhkT7k58uvWTB/Gy26eA/EJKtPZFVAhEilN5UYVmmGRYOURbejRUyKm0Uu9XVEW7K5nBOZfR8VMB4QR2RQ==",
           "dev": true,
           "requires": {
@@ -30173,7 +30173,7 @@
           "dependencies": {
             "@sinonjs/fake-timers": {
               "version": "11.2.2",
-              "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz",
               "integrity": "sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==",
               "dev": true,
               "requires": {
@@ -30184,13 +30184,13 @@
         },
         "path-to-regexp": {
           "version": "6.2.1",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.1.tgz",
           "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw==",
           "dev": true
         },
         "sinon": {
           "version": "16.1.3",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/sinon/-/sinon-16.1.3.tgz",
+          "resolved": "https://registry.npmjs.org/sinon/-/sinon-16.1.3.tgz",
           "integrity": "sha512-mjnWWeyxcAf9nC0bXcPmiDut+oE8HYridTNzBbF98AYVLmWwGRp2ISEpyhYflG1ifILT+eNn3BmKUJPxjXUPlA==",
           "dev": true,
           "requires": {
@@ -30204,7 +30204,7 @@
         },
         "supports-color": {
           "version": "7.2.0",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/supports-color/-/supports-color-7.2.0.tgz",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
           "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
           "dev": true,
           "requires": {
@@ -30213,7 +30213,7 @@
         },
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
           "dev": true
         }
@@ -30221,7 +30221,7 @@
     },
     "aws-sdk-client-mock-jest": {
       "version": "3.0.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/aws-sdk-client-mock-jest/-/aws-sdk-client-mock-jest-3.0.1.tgz",
+      "resolved": "https://registry.npmjs.org/aws-sdk-client-mock-jest/-/aws-sdk-client-mock-jest-3.0.1.tgz",
       "integrity": "sha512-eT0i+XkvitMt7ml2LVUayVd6oiFO7SqLQBEbRId094fs2qlWlL+Png0WuOFVCIcTZgjoK5v81UnKSLwFbbpWqA==",
       "dev": true,
       "requires": {
@@ -30231,7 +30231,7 @@
       "dependencies": {
         "tslib": {
           "version": "2.6.2",
-          "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/tslib/-/tslib-2.6.2.tgz",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
           "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
           "dev": true
         }
@@ -30443,7 +30443,7 @@
     },
     "bowser": {
       "version": "2.11.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/bowser/-/bowser-2.11.0.tgz",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "brace-expansion": {
@@ -30670,7 +30670,7 @@
     },
     "chalk": {
       "version": "2.4.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/chalk/-/chalk-2.4.2.tgz",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
       "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
       "dev": true,
       "requires": {
@@ -32735,7 +32735,7 @@
     },
     "fast-xml-parser": {
       "version": "4.2.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.2.5.tgz",
       "integrity": "sha512-B9/wizE4WngqQftFPmdaMYlXoJlJOYxGQOanC77fq9k8+Z0v5dDSVh+3glErdIROP//s/jgb7ZuxKfB8nVyo0g==",
       "requires": {
         "strnum": "^1.0.5"
@@ -33036,7 +33036,7 @@
     },
     "function-bind": {
       "version": "1.1.2",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/function-bind/-/function-bind-1.1.2.tgz",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
       "dev": true
     },
@@ -33304,7 +33304,7 @@
     },
     "hasown": {
       "version": "2.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/hasown/-/hasown-2.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
       "dev": true,
       "requires": {
@@ -33807,7 +33807,7 @@
     },
     "is-core-module": {
       "version": "2.13.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/is-core-module/-/is-core-module-2.13.1.tgz",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
       "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
       "dev": true,
       "requires": {
@@ -35586,7 +35586,7 @@
     },
     "js-tokens": {
       "version": "4.0.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/js-tokens/-/js-tokens-4.0.0.tgz",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true
     },
@@ -37958,7 +37958,7 @@
     },
     "semver": {
       "version": "6.3.1",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/semver/-/semver-6.3.1.tgz",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
       "dev": true
     },
@@ -38940,7 +38940,7 @@
     },
     "strnum": {
       "version": "1.0.5",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/strnum/-/strnum-1.0.5.tgz",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
       "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
     },
     "strtok3": {
@@ -39008,7 +39008,7 @@
     },
     "supports-color": {
       "version": "5.5.0",
-      "resolved": "https://jfrog.trendmicro.com/artifactory/api/npm/conformity-npm_virtual/supports-color/-/supports-color-5.5.0.tgz",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
       "dev": true,
       "requires": {


### PR DESCRIPTION
### Issue Link:

auto-remediate is currently broken as it tries to download dependencies from internal artifactory.

### What does it do?

- `package-lock.json` currently references internal jfrog endpoints which our customers do not have access to. This means customers cannot run `npm install` as they will get a 401 error.
- This PR does a find and replace to put back the correct registry, npm install has been run to validate the integrity and reach-ability of the packages.

#### Checklist


- [ ] BREAKING CHANGE - I have/intend to update all places where this package is used.
- [ ] I will squash: PR title conforms to standard commit message format (`feat: XX-1234 ...`)
- [x] I will merge without squashing: All commits conforms to standard commit message format (`feat: XX-1234 ...`)
- [ ] README update


---

#### Notes to reviewers

(eg. Majority of LOC changes were prettier. Specific file to look at is package.json)

#### Screenshots

(eg. _A picture is worth 1000 words..._)

#### Related PR's

(eg. https://github.com/cloudconformity/.github/pull/1)
